### PR TITLE
Pokewalker & spiky-eared Pichu PID generation

### DIFF
--- a/asm/overlay_112.s
+++ b/asm/overlay_112.s
@@ -17969,7 +17969,7 @@ _021EEA06:
 	add r0, r7, #0
 	lsr r2, r2, #0x18
 	add r3, r6, #0
-	bl sub_02072490
+	bl ChangePersonalityToNatureGenderAndAbility
 	mov r1, #1
 	str r1, [sp]
 	str r0, [sp, #4]

--- a/asm/scrcmd_pokemon_misc.s
+++ b/asm/scrcmd_pokemon_misc.s
@@ -2928,9 +2928,9 @@ _02202224:
 	mov r1, #0
 	str r1, [sp]
 	str r1, [sp, #4]
-	mov r1, #0xac
-	mov r2, #4
-	mov r3, #1
+	mov r1, #SPECIES_PICHU
+	mov r2, #NATURE_NAUGHTY
+	mov r3, #1 ; MON_FEMALE
 	add r4, r0, #0
 	bl ChangePersonalityToNatureGenderAndAbility
 	mov r1, #1

--- a/asm/scrcmd_pokemon_misc.s
+++ b/asm/scrcmd_pokemon_misc.s
@@ -2932,7 +2932,7 @@ _02202224:
 	mov r2, #4
 	mov r3, #1
 	add r4, r0, #0
-	bl sub_02072490
+	bl ChangePersonalityToNatureGenderAndAbility
 	mov r1, #1
 	str r1, [sp]
 	str r0, [sp, #4]

--- a/global.inc
+++ b/global.inc
@@ -29679,7 +29679,7 @@
 .public sub_020720D4
 .public sub_020720FC
 .public sub_0207217C
-.public sub_02072490
+.public ChangePersonalityToNatureGenderAndAbility
 .public sub_02072914
 .public sub_0207294C
 .public sub_020729A4

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -175,7 +175,7 @@ BOOL GetMonTMHMCompat(POKEMON *pokemon, u8 tmhm);
 BOOL GetBoxMonTMHMCompat(BOXMON *boxmon, u8 tmhm);
 BOOL GetTMHMCompatBySpeciesAndForme(u16 species, u32 forme, u8 tmhm);
 void SetMonPersonality(struct Pokemon * r5, u32 personality);
-u32 sub_02072490(u32 pid, u16 species, u8 nature, u8 gender, u8 ability, BOOL gen_mode);
+u32 ChangePersonalityToNatureGenderAndAbility(u32 pid, u16 species, u8 nature, u8 gender, u8 ability, BOOL gen_mode);
 void LoadMonPersonal(int species, BASE_STATS *personal);
 void LoadMonBaseStats_HandleAlternateForme(int species, int forme, BASE_STATS *personal);
 void LoadMonEvolutionTable(u16 species, struct Evolution *evo);


### PR DESCRIPTION
For PKHeX reasons I examined how the personality values for Pokemon found on the Pokewalker are generated. This led me to an undocumented function, which I documented and renamed. The function is also used to generate the PID for the spiky-eared Pichu, and I documented some constants there as well.

As always I've made these edits without a build system installed so advance apologies for any errors.