### PR TITLE
Fix build on Fedora 38

### DIFF
--- a/tools/mod123encry/Decrypt.h
+++ b/tools/mod123encry/Decrypt.h
@@ -1,6 +1,7 @@
 #ifndef GUARD_DECRYPT_H
 #define GUARD_DECRYPT_H
 
+#include <cstdint>
 #include "NtrRom.h"
 #include "Options.h"
 

--- a/tools/msgenc/Options.h
+++ b/tools/msgenc/Options.h
@@ -1,6 +1,7 @@
 #ifndef GUARD_OPTIONS_H
 #define GUARD_OPTIONS_H
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
It's necessary to explicitly include cstdint when compiling pokeheartgold on Fedora 38.