### PR TITLE
synchronise bg_window.c with diamond

### DIFF
--- a/asm/include/overlay_01_021E5900.inc
+++ b/asm/include/overlay_01_021E5900.inc
@@ -24,7 +24,7 @@
 .public FreeBgTilemapBuffer
 .public BG_ClearCharDataRange
 .public BgClearTilemapBufferAndCommit
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public sub_0201F590
 .public sub_0201F63C
 .public GF_CreateVramTransferManager

--- a/asm/include/overlay_05.inc
+++ b/asm/include/overlay_05.inc
@@ -106,7 +106,7 @@
 .public ScheduleWindowCopyToVram
 .public FillWindowPixelBuffer
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public sub_0201F988

--- a/asm/include/overlay_100.inc
+++ b/asm/include/overlay_100.inc
@@ -84,7 +84,7 @@
 .public BG_LoadBlankPltt
 .public CopyToBgTilemapRect
 .public BgClearTilemapBufferAndCommit
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public DoesPixelAtScreenXYMatchPtrVal
 .public GF_CreateVramTransferManager

--- a/asm/include/overlay_102.inc
+++ b/asm/include/overlay_102.inc
@@ -106,7 +106,7 @@
 .public FillWindowPixelBufferText_AssumeTileSize32
 .public BlitBitmapRectToWindow
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public sub_0201F988
 .public MsgArray_SkipControlCode

--- a/asm/include/overlay_103.inc
+++ b/asm/include/overlay_103.inc
@@ -111,7 +111,7 @@
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
 .public BlitBitmapRectToWindow
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_106.inc
+++ b/asm/include/overlay_106.inc
@@ -58,7 +58,7 @@
 .public BG_ClearCharDataRange
 .public BG_SetMaskColor
 .public BgClearTilemapBufferAndCommit
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public sub_0201F51C
 .public Draw3dModel
 .public sub_0201F590

--- a/asm/include/overlay_108.inc
+++ b/asm/include/overlay_108.inc
@@ -136,7 +136,7 @@
 .public FillWindowPixelRect
 .public GetWindowWidth
 .public GetWindowHeight
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public DoesPixelAtScreenXYMatchPtrVal
 .public Draw3dModel

--- a/asm/include/overlay_109.inc
+++ b/asm/include/overlay_109.inc
@@ -84,7 +84,7 @@
 .public ScheduleWindowCopyToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_110.inc
+++ b/asm/include/overlay_110.inc
@@ -79,7 +79,7 @@
 .public ScheduleWindowCopyToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_111.inc
+++ b/asm/include/overlay_111.inc
@@ -82,7 +82,7 @@
 .public GetWindowBgId
 .public GetWindowX
 .public GetWindowY
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public ResetAllTextPrinters

--- a/asm/include/overlay_112.inc
+++ b/asm/include/overlay_112.inc
@@ -149,7 +149,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_SinDeg
 .public GF_CosDeg
 .public SetLCRNGSeed

--- a/asm/include/overlay_113.inc
+++ b/asm/include/overlay_113.inc
@@ -74,7 +74,7 @@
 .public ScheduleWindowCopyToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public AddTextPrinterParameterized2
 .public GF_CreateVramTransferManager

--- a/asm/include/overlay_121.inc
+++ b/asm/include/overlay_121.inc
@@ -61,7 +61,7 @@
 .public CopyWindowToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ResetAllTextPrinters
 .public AddTextPrinterParameterized2
 .public GF_RunVramTransferTasks

--- a/asm/include/overlay_12_022378C0.inc
+++ b/asm/include/overlay_12_022378C0.inc
@@ -91,7 +91,7 @@
 .public RemoveWindow
 .public WindowArray_Delete
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GetLCRNGSeed
 .public SetLCRNGSeed
 .public AddTextPrinterParameterized

--- a/asm/include/overlay_14.inc
+++ b/asm/include/overlay_14.inc
@@ -177,7 +177,7 @@
 .public GetWindowX
 .public GetWindowY
 .public GetWindowBaseTile
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_15.inc
+++ b/asm/include/overlay_15.inc
@@ -111,7 +111,7 @@
 .public BlitBitmapRectToWindow
 .public FillWindowPixelRect
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public sub_0201F51C
 .public Draw3dModel

--- a/asm/include/overlay_17.inc
+++ b/asm/include/overlay_17.inc
@@ -95,7 +95,7 @@
 .public ScheduleWindowCopyToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public AddTextPrinterParameterized
 .public AddTextPrinterParameterized2
 .public GF_CreateVramTransferManager

--- a/asm/include/overlay_18.inc
+++ b/asm/include/overlay_18.inc
@@ -186,7 +186,7 @@
 .public GetWindowX
 .public GetWindowY
 .public GetWindowBaseTile
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_37.inc
+++ b/asm/include/overlay_37.inc
@@ -66,7 +66,7 @@
 .public FillWindowPixelBuffer
 .public BlitBitmapRectToWindow
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_SinDeg
 .public TextPrinterCheckActive
 .public sub_020200A0

--- a/asm/include/overlay_39_thumb.inc
+++ b/asm/include/overlay_39_thumb.inc
@@ -61,7 +61,7 @@
 .public AddWindowParameterized
 .public RemoveWindow
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_40.inc
+++ b/asm/include/overlay_40.inc
@@ -138,7 +138,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_SinDeg
 .public GF_CosDeg
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_41.inc
+++ b/asm/include/overlay_41.inc
@@ -132,7 +132,7 @@
 .public CopyWindowToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public sub_0201F988

--- a/asm/include/overlay_43.inc
+++ b/asm/include/overlay_43.inc
@@ -109,7 +109,7 @@
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
 .public BlitBitmapRectToWindow
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public TextPrinterCheckActive

--- a/asm/include/overlay_44.inc
+++ b/asm/include/overlay_44.inc
@@ -138,7 +138,7 @@
 .public BlitBitmapRectToWindow
 .public FillWindowPixelRect
 .public SetWindowPaletteNum
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public GF_SinDegNoWrap
 .public MTRandom

--- a/asm/include/overlay_46.inc
+++ b/asm/include/overlay_46.inc
@@ -55,7 +55,7 @@
 .public ScheduleWindowCopyToVram
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public TextPrinterCheckActive
 .public sub_020200A0
 .public AddTextPrinterParameterized

--- a/asm/include/overlay_47.inc
+++ b/asm/include/overlay_47.inc
@@ -73,7 +73,7 @@
 .public FillWindowPixelBuffer
 .public BlitBitmapRectToWindow
 .public SetWindowPaletteNum
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public TextPrinterCheckActive
 .public sub_020200A0
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_48.inc
+++ b/asm/include/overlay_48.inc
@@ -88,7 +88,7 @@
 .public FillWindowPixelBuffer
 .public GetWindowBgConfig
 .public GetWindowBaseTile
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public GF_DegreeToSinCosIdxNoWrap
 .public TextPrinterCheckActive

--- a/asm/include/overlay_49.inc
+++ b/asm/include/overlay_49.inc
@@ -140,7 +140,7 @@
 .public FillWindowPixelBuffer
 .public FillWindowPixelRect
 .public SetWindowPaletteNum
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public Bind3dModelSet

--- a/asm/include/overlay_53.inc
+++ b/asm/include/overlay_53.inc
@@ -91,7 +91,7 @@
 .public CopyWindowToVram
 .public FillWindowPixelBuffer
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleSetBgPosText
 .public GF_SinDeg
 .public ResetAllTextPrinters

--- a/asm/include/overlay_54.inc
+++ b/asm/include/overlay_54.inc
@@ -63,7 +63,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public TextPrinterCheckActive
 .public sub_020200A0
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_56.inc
+++ b/asm/include/overlay_56.inc
@@ -83,7 +83,7 @@
 .public CopyWindowToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public DoesPixelAtScreenXYMatchPtrVal
 .public TextPrinterCheckActive

--- a/asm/include/overlay_57.inc
+++ b/asm/include/overlay_57.inc
@@ -139,7 +139,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public DoesPixelAtScreenXYMatchPtrVal
 .public AddTextPrinterParameterized
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_59.inc
+++ b/asm/include/overlay_59.inc
@@ -112,7 +112,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public GF_DegreeToSinCosIdx
 .public TextPrinterCheckActive

--- a/asm/include/overlay_60.inc
+++ b/asm/include/overlay_60.inc
@@ -93,7 +93,7 @@
 .public AddWindow
 .public RemoveWindow
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public sub_0201F51C

--- a/asm/include/overlay_62.inc
+++ b/asm/include/overlay_62.inc
@@ -67,7 +67,7 @@
 .public ClearWindowTilemap
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public sub_0201F988
 .public GF_SinDegNoWrap
 .public LCRandom

--- a/asm/include/overlay_63.inc
+++ b/asm/include/overlay_63.inc
@@ -90,7 +90,7 @@
 .public ScheduleWindowCopyToVram
 .public CopyWindowPixelsToVram_TextMode
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public sub_0201F988

--- a/asm/include/overlay_64.inc
+++ b/asm/include/overlay_64.inc
@@ -79,7 +79,7 @@
 .public ScheduleWindowCopyToVram
 .public CopyWindowPixelsToVram_TextMode
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public AddTextPrinterParameterized2
 .public sub_020210BC
 .public sub_02021148

--- a/asm/include/overlay_65.inc
+++ b/asm/include/overlay_65.inc
@@ -108,7 +108,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_SinDeg
 .public LCRandom
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_67.inc
+++ b/asm/include/overlay_67.inc
@@ -75,7 +75,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public AddTextPrinterParameterized2
 .public sub_02020A0C

--- a/asm/include/overlay_68.inc
+++ b/asm/include/overlay_68.inc
@@ -105,7 +105,7 @@
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized

--- a/asm/include/overlay_70.inc
+++ b/asm/include/overlay_70.inc
@@ -133,7 +133,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public sub_0201F988
 .public LCRandom
 .public TextPrinterCheckActive

--- a/asm/include/overlay_72.inc
+++ b/asm/include/overlay_72.inc
@@ -82,7 +82,7 @@
 .public CopyWindowToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized

--- a/asm/include/overlay_73.inc
+++ b/asm/include/overlay_73.inc
@@ -91,7 +91,7 @@
 .public RemoveWindow
 .public CopyWindowToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public DoesPixelAtScreenXYMatchPtrVal
 .public GF_SinDeg

--- a/asm/include/overlay_74_thumb.inc
+++ b/asm/include/overlay_74_thumb.inc
@@ -128,7 +128,7 @@
 .public GetWindowY
 .public SetWindowX
 .public SetWindowY
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public DoesPixelAtScreenXYMatchPtrVal

--- a/asm/include/overlay_75.inc
+++ b/asm/include/overlay_75.inc
@@ -82,7 +82,7 @@
 .public CopyWindowToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized

--- a/asm/include/overlay_78.inc
+++ b/asm/include/overlay_78.inc
@@ -64,7 +64,7 @@
 .public AddWindow
 .public RemoveWindow
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleSetBgPosText
 .public ResetAllTextPrinters
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_80_02238648.inc
+++ b/asm/include/overlay_80_02238648.inc
@@ -67,7 +67,7 @@
 .public ToggleBgLayer
 .public BgSetPosTextAndCommit
 .public BgClearTilemapBufferAndCommit
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public GF_CreateVramTransferManager

--- a/asm/include/overlay_81.inc
+++ b/asm/include/overlay_81.inc
@@ -121,7 +121,7 @@
 .public GetWindowBgId
 .public GetWindowWidth
 .public SetWindowX
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_82.inc
+++ b/asm/include/overlay_82.inc
@@ -88,7 +88,7 @@
 .public GetWindowHeight
 .public GetWindowX
 .public GetWindowY
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_83.inc
+++ b/asm/include/overlay_83.inc
@@ -123,7 +123,7 @@
 .public FillWindowPixelRect
 .public GetWindowBgId
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public AddTextPrinterParameterized2
 .public GF_CreateVramTransferManager

--- a/asm/include/overlay_85.inc
+++ b/asm/include/overlay_85.inc
@@ -122,7 +122,7 @@
 .public ScheduleWindowCopyToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_SinDegNoWrap
 .public GF_CosDegNoWrap
 .public GF_SinDeg

--- a/asm/include/overlay_86.inc
+++ b/asm/include/overlay_86.inc
@@ -85,7 +85,7 @@
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_87.inc
+++ b/asm/include/overlay_87.inc
@@ -88,7 +88,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public GetWindowBgId
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public LCRandom
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_88.inc
+++ b/asm/include/overlay_88.inc
@@ -51,7 +51,7 @@
 .public FillWindowPixelBuffer
 .public BlitBitmapRect
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public AddTextPrinterParameterized
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_89.inc
+++ b/asm/include/overlay_89.inc
@@ -123,7 +123,7 @@
 .public CopyWindowToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public Bind3dModelSet
 .public GF_SinDegFX32

--- a/asm/include/overlay_90.inc
+++ b/asm/include/overlay_90.inc
@@ -94,7 +94,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public MTRandom

--- a/asm/include/overlay_91.inc
+++ b/asm/include/overlay_91.inc
@@ -100,7 +100,7 @@
 .public FillWindowPixelRect
 .public SetWindowX
 .public SetWindowY
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_SinDegNoWrap
 .public GF_CosDegNoWrap
 .public GF_DegreeToSinCosIdxNoWrap

--- a/asm/include/overlay_92.inc
+++ b/asm/include/overlay_92.inc
@@ -109,7 +109,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleSetBgPosText
 .public GF_SinDeg
 .public GF_CosDeg

--- a/asm/include/overlay_93_thumb_1.inc
+++ b/asm/include/overlay_93_thumb_1.inc
@@ -113,7 +113,7 @@
 .public RemoveWindow
 .public ScheduleWindowCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public AllocAndLoad3dTexResources
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_95.inc
+++ b/asm/include/overlay_95.inc
@@ -121,7 +121,7 @@
 .public CopyWindowToVram
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_96.inc
+++ b/asm/include/overlay_96.inc
@@ -197,7 +197,7 @@
 .public ClearWindowTilemapAndCopyToVram
 .public FillWindowPixelBuffer
 .public FillWindowPixelBufferText_AssumeTileSize32
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public GF_SinDeg

--- a/asm/include/overlay_99.inc
+++ b/asm/include/overlay_99.inc
@@ -61,7 +61,7 @@
 .public BgClearTilemapBufferAndCommit
 .public ScheduleWindowCopyToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleSetBgPosText
 .public sub_02020A0C
 .public GX_DisableEngineALayers

--- a/asm/include/overlay_trainer_card_main.inc
+++ b/asm/include/overlay_trainer_card_main.inc
@@ -89,7 +89,7 @@
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized2

--- a/asm/include/overlay_trainer_card_signature.inc
+++ b/asm/include/overlay_trainer_card_signature.inc
@@ -69,7 +69,7 @@
 .public CopyWindowToVram
 .public FillWindowPixelBuffer
 .public BlitBitmapRectToWindow
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_SinDeg
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized

--- a/asm/include/unk_020755E8.inc
+++ b/asm/include/unk_020755E8.inc
@@ -106,7 +106,7 @@
 .public WindowArray_Delete
 .public CopyWindowToVram
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized
 .public AddTextPrinterParameterized2

--- a/asm/include/unk_02078E30.inc
+++ b/asm/include/unk_02078E30.inc
@@ -72,7 +72,7 @@
 .public BgClearTilemapBufferAndCommit
 .public ClearWindowTilemapAndScheduleTransfer
 .public FillWindowPixelBuffer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public TextPrinterCheckActive
 .public GF_DestroyVramTransferManager

--- a/asm/include/unk_020850F4.inc
+++ b/asm/include/unk_020850F4.inc
@@ -25,7 +25,7 @@
 .public InitBgFromTemplate
 .public FreeBgTilemapBuffer
 .public BgClearTilemapBufferAndCommit
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public GF_RunVramTransferTasks
 .public sub_020210BC
 .public sub_02021148

--- a/asm/include/unk_02088288.inc
+++ b/asm/include/unk_02088288.inc
@@ -66,7 +66,7 @@
 .public BgClearTilemapBufferAndCommit
 .public ScheduleWindowCopyToVram
 .public ClearWindowTilemapAndScheduleTransfer
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public ScheduleSetBgPosText
 .public GF_DestroyVramTransferManager

--- a/asm/include/unk_02091CDC.inc
+++ b/asm/include/unk_02091CDC.inc
@@ -38,7 +38,7 @@
 .public AddWindow
 .public RemoveWindow
 .public FillWindowPixelRect
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ResetAllTextPrinters
 .public TextPrinterCheckActive
 .public AddTextPrinterParameterized

--- a/asm/include/unk_020932E0.inc
+++ b/asm/include/unk_020932E0.inc
@@ -51,7 +51,7 @@
 .public FillWindowPixelBuffer
 .public GetWindowBgConfig
 .public GetWindowWidth
-.public BgConfig_HandleScheduledScrollAndTransferOps
+.public DoScheduledBgGpuUpdates
 .public ScheduleBgTilemapBufferTransfer
 .public AddTextPrinterParameterized2
 .public GF_RunVramTransferTasks

--- a/asm/overlay_01_021E5900.s
+++ b/asm/overlay_01_021E5900.s
@@ -21,7 +21,7 @@ ov01_021E5900: ; 0x021E5900
 	push {r4, lr}
 	add r4, r0, #0
 	ldr r0, [r4, #8]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r0, [r4, #0x3c]

--- a/asm/overlay_05.s
+++ b/asm/overlay_05.s
@@ -2561,7 +2561,7 @@ ov05_0221CE88: ; 0x0221CE88
 	push {r4, lr}
 	add r4, r0, #0
 	ldr r0, [r4, #0xc]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r0, [r4, #8]
 	bl sub_0200398C
 	bl GF_RunVramTransferTasks

--- a/asm/overlay_100.s
+++ b/asm/overlay_100.s
@@ -1695,7 +1695,7 @@ _021E6632:
 _021E663C:
 	bl GF_RunVramTransferTasks
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E6654 ; =0x027E0000
 	ldr r1, _021E6658 ; =0x00003FF8
 	mov r0, #1
@@ -1822,21 +1822,21 @@ _021E6706:
 _021E670E:
 	strb r1, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #2
 	pop {r4, pc}
 _021E671A:
 	mov r0, #1
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #4
 	pop {r4, pc}
 _021E6728:
 	mov r0, #3
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #0xa
 	pop {r4, pc}
 _021E6736:
@@ -1962,21 +1962,21 @@ _021E6812:
 	mov r0, #2
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #6
 	pop {r4, pc}
 _021E6820:
 	mov r0, #1
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #4
 	pop {r4, pc}
 _021E682E:
 	mov r0, #3
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #0xa
 	pop {r4, pc}
 _021E683C:
@@ -2022,20 +2022,20 @@ _021E686A:
 	mov r0, #2
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #6
 	pop {r4, pc}
 _021E688A:
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #2
 	pop {r4, pc}
 _021E6896:
 	mov r0, #1
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #4
 	pop {r4, pc}
 _021E68A4:
@@ -2083,20 +2083,20 @@ _021E68E6:
 	mov r0, #2
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #6
 	pop {r4, pc}
 _021E68F4:
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #2
 	pop {r4, pc}
 _021E6900:
 	mov r0, #3
 	strb r0, [r4, #4]
 	ldr r0, [r4, #0x74]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #0xa
 	pop {r4, pc}
 _021E690E:

--- a/asm/overlay_102.s
+++ b/asm/overlay_102.s
@@ -3941,7 +3941,7 @@ ov102_021E93E0: ; 0x021E93E0
 	push {r4, lr}
 	add r4, r1, #0
 	ldr r0, [r4, #0x20]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r0, [r4, #0x24]
 	bl sub_0202457C
 	bl OamManager_ApplyAndResetBuffers

--- a/asm/overlay_103.s
+++ b/asm/overlay_103.s
@@ -70,7 +70,7 @@ ov103_021EC9B4: ; 0x021EC9B4
 	push {r3, lr}
 	ldr r0, [r0, #0xc]
 	ldr r0, [r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl sub_0200D034
 	ldr r3, _021EC9D0 ; =0x027E0000
 	ldr r1, _021EC9D4 ; =0x00003FF8

--- a/asm/overlay_106.s
+++ b/asm/overlay_106.s
@@ -1449,7 +1449,7 @@ ov106_021E63E0: ; 0x021E63E0
 	add r4, r0, #0
 	bl ov106_021E6A34
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl sub_0200D034
 	ldr r3, _021E6400 ; =0x027E0000
 	ldr r1, _021E6404 ; =0x00003FF8

--- a/asm/overlay_108.s
+++ b/asm/overlay_108.s
@@ -2423,7 +2423,7 @@ _021E6C16:
 	mov r0, #0xd
 	lsl r0, r0, #6
 	ldr r0, [r4, r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E6C40 ; =0x027E0000
 	ldr r1, _021E6C44 ; =0x00003FF8
 	mov r0, #1
@@ -7962,7 +7962,7 @@ _021E9800:
 	bl GF_RunVramTransferTasks
 	ldr r0, _021E9824 ; =0x00000438
 	ldr r0, [r4, r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E9828 ; =0x027E0000
 	ldr r1, _021E982C ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_109.s
+++ b/asm/overlay_109.s
@@ -2048,7 +2048,7 @@ _021E686C:
 	bl ov109_021E68D4
 	bl NNS_GfdDoVramTransfer
 	ldr r0, [r4, #0x14]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E6890 ; =0x027E0000
 	ldr r1, _021E6894 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_110.s
+++ b/asm/overlay_110.s
@@ -1121,7 +1121,7 @@ _021E6120:
 _021E612E:
 	bl NNS_GfdDoVramTransfer
 	ldr r0, [r4, #0x14]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E6148 ; =0x027E0000
 	ldr r1, _021E614C ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_111.s
+++ b/asm/overlay_111.s
@@ -682,7 +682,7 @@ _021E5E0E:
 	bl sub_0200D020
 	bl sub_0200D034
 	ldr r0, [r4, #8]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E5E2C ; =0x027E0000
 	ldr r1, _021E5E30 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_112.s
+++ b/asm/overlay_112.s
@@ -4231,7 +4231,7 @@ _021E79A4: .word 0x0001E444
 ov112_021E79A8: ; 0x021E79A8
 	push {r3, lr}
 	ldr r0, [r0, #0x18]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl sub_0200D034
 	ldr r3, _021E79C8 ; =0x027E0000
@@ -26776,7 +26776,7 @@ _021F2ECE:
 	bl sub_0200D020
 	bl sub_0200D034
 	ldr r0, [r4, #0x14]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021F2EEC ; =0x027E0000
 	ldr r1, _021F2EF0 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_113.s
+++ b/asm/overlay_113.s
@@ -1294,7 +1294,7 @@ ov113_021E62B0: ; 0x021E62B0
 _021E62C0:
 	bl GF_RunVramTransferTasks
 	ldr r0, [r4, #0x40]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E62D8 ; =0x027E0000
 	ldr r1, _021E62DC ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_121.s
+++ b/asm/overlay_121.s
@@ -749,7 +749,7 @@ ov121_021E5F30: ; 0x021E5F30
 	add r4, r0, #0
 	bl OamManager_ApplyAndResetBuffers
 	add r0, r4, #0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	ldr r3, _021E5F50 ; =0x027E0000
 	ldr r1, _021E5F54 ; =0x00003FF8

--- a/asm/overlay_12_022378C0.s
+++ b/asm/overlay_12_022378C0.s
@@ -3674,7 +3674,7 @@ _02239798:
 	ldr r0, [r4, #0x28]
 	bl sub_0200398C
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _022397DC ; =0x027E0000
 	ldr r1, _022397E0 ; =0x00003FF8
 	mov r0, #1
@@ -3701,7 +3701,7 @@ ov12_022397E4: ; 0x022397E4
 	bl sub_0200398C
 	bl GF_RunVramTransferTasks
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02239808 ; =0x027E0000
 	ldr r1, _0223980C ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_14.s
+++ b/asm/overlay_14.s
@@ -112,7 +112,7 @@ _021E59C6:
 	bl sub_0200398C
 	ldr r0, [r4, #0x34]
 	ldr r0, [r0, #0x14]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r0, [r4, #0x34]
 	bl ov14_021F29C4
 	ldr r1, [r4, #0x34]

--- a/asm/overlay_15.s
+++ b/asm/overlay_15.s
@@ -705,7 +705,7 @@ BagApp_SetFlute: ; 0x021F994C
 ov15_021F995C: ; 0x021F995C
 	push {r3, lr}
 	ldr r0, [r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl sub_0200D034
 	ldr r3, _021F997C ; =0x027E0000

--- a/asm/overlay_17.s
+++ b/asm/overlay_17.s
@@ -2125,7 +2125,7 @@ _02202C0A:
 	bl NNS_GfdDoVramTransfer
 	add r4, #0x88
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02202C24 ; =0x027E0000
 	ldr r1, _02202C28 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_18.s
+++ b/asm/overlay_18.s
@@ -456,7 +456,7 @@ ov18_021E5C40: ; 0x021E5C40
 	add r0, r4, #0
 	bl ov18_021E7A3C
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl sub_0200D034
 	ldr r3, _021E5C6C ; =0x027E0000
 	ldr r1, _021E5C70 ; =0x00003FF8

--- a/asm/overlay_37.s
+++ b/asm/overlay_37.s
@@ -438,7 +438,7 @@ ov37_021E5CC8: ; 0x021E5CC8
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	add r0, r4, #0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E5CE8 ; =0x027E0000
 	ldr r1, _021E5CEC ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_39_thumb.s
+++ b/asm/overlay_39_thumb.s
@@ -2683,7 +2683,7 @@ ov39_02228418: ; 0x02228418
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02228438 ; =0x027E0000
 	ldr r1, _0222843C ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_40.s
+++ b/asm/overlay_40.s
@@ -671,7 +671,7 @@ ov40_0222BD04: ; 0x0222BD04
 	ldr r0, [r4, #0x28]
 	bl sub_0200398C
 	ldr r0, [r4, #0x24]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _0222BD28 ; =0x027E0000
 	ldr r1, _0222BD2C ; =0x00003FF8
 	mov r0, #1
@@ -20112,7 +20112,7 @@ _02235918:
 	ldr r0, [r4, #0x28]
 	bl sub_0200398C
 	ldr r0, [r4, #0x24]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02235938 ; =0x027E0000
 	ldr r1, _0223593C ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_41.s
+++ b/asm/overlay_41.s
@@ -846,7 +846,7 @@ ov41_02246494: ; 0x02246494
 	push {r4, lr}
 	add r4, r0, #0
 	ldr r0, [r4, #0x40]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r0, [r4, #0x20]
 	bl sub_02009418
 	bl OamManager_ApplyAndResetBuffers
@@ -1132,7 +1132,7 @@ ov41_02246698: ; 0x02246698
 ov41_022466B8: ; 0x022466B8
 	push {r3, lr}
 	ldr r0, [r0, #0x40]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}
 	.balign 4, 0

--- a/asm/overlay_43.s
+++ b/asm/overlay_43.s
@@ -785,7 +785,7 @@ _0222A508: .word sub_0202457C
 ov43_0222A50C: ; 0x0222A50C
 	push {r3, lr}
 	ldr r0, [r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}

--- a/asm/overlay_44.s
+++ b/asm/overlay_44.s
@@ -1233,7 +1233,7 @@ ov44_0222A7F8: ; 0x0222A7F8
 	mov r0, #0x57
 	lsl r0, r0, #2
 	ldr r0, [r4, r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r0, _0222A82C ; =0x000010BC
@@ -18610,7 +18610,7 @@ _02233198:
 ov44_0223319C: ; 0x0223319C
 	push {r3, lr}
 	ldr r0, [r0, #0x30]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}

--- a/asm/overlay_46.s
+++ b/asm/overlay_46.s
@@ -1324,11 +1324,11 @@ _022592DC: .word _02259598
 
 	thumb_func_start ov46_022592E0
 ov46_022592E0: ; 0x022592E0
-	ldr r3, _022592E8 ; =BgConfig_HandleScheduledScrollAndTransferOps
+	ldr r3, _022592E8 ; =DoScheduledBgGpuUpdates
 	ldr r0, [r0, #0xc]
 	bx r3
 	nop
-_022592E8: .word BgConfig_HandleScheduledScrollAndTransferOps
+_022592E8: .word DoScheduledBgGpuUpdates
 	thumb_func_end ov46_022592E0
 
 	thumb_func_start ov46_022592EC

--- a/asm/overlay_47.s
+++ b/asm/overlay_47.s
@@ -324,7 +324,7 @@ _02258A88: .word sub_0202457C
 ov47_02258A8C: ; 0x02258A8C
 	push {r3, lr}
 	ldr r0, [r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	bl GF_RunVramTransferTasks
 	pop {r3, pc}

--- a/asm/overlay_48.s
+++ b/asm/overlay_48.s
@@ -1669,7 +1669,7 @@ _022594D8: .word sub_0202457C
 ov48_022594DC: ; 0x022594DC
 	push {r3, lr}
 	ldr r0, [r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	bl GF_RunVramTransferTasks
 	pop {r3, pc}

--- a/asm/overlay_49.s
+++ b/asm/overlay_49.s
@@ -4465,7 +4465,7 @@ _0225A83C: .word ov49_02269734
 ov49_0225A840: ; 0x0225A840
 	push {r3, lr}
 	ldr r0, [r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	bl GF_RunVramTransferTasks
 	pop {r3, pc}

--- a/asm/overlay_53.s
+++ b/asm/overlay_53.s
@@ -329,7 +329,7 @@ _021E5BC8: .word ov36_App_InitGameState_AfterOakSpeech
 ov53_021E5BCC: ; 0x021E5BCC
 	push {r3, lr}
 	ldr r0, [r0, #0x18]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl sub_0200D034
 	pop {r3, pc}
 	.balign 4, 0

--- a/asm/overlay_54.s
+++ b/asm/overlay_54.s
@@ -461,7 +461,7 @@ _021E5CB4:
 	bl sub_0200D034
 	bl NNS_GfdDoVramTransfer
 	ldr r0, [r4, #0x14]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E5CDC ; =0x027E0000
 	ldr r1, _021E5CE0 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_56.s
+++ b/asm/overlay_56.s
@@ -1022,7 +1022,7 @@ _021E63CE:
 _021E63DC:
 	bl NNS_GfdDoVramTransfer
 	ldr r0, [r4, #0x18]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E63F4 ; =0x027E0000
 	ldr r1, _021E63F8 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_57.s
+++ b/asm/overlay_57.s
@@ -628,7 +628,7 @@ ov57_02237E38: ; 0x02237E38
 	bl sub_0200398C
 	add r4, #0xe4
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	ldr r3, _02237E70 ; =0x027E0000
 	ldr r1, _02237E74 ; =0x00003FF8

--- a/asm/overlay_59.s
+++ b/asm/overlay_59.s
@@ -2924,7 +2924,7 @@ ov59_022393D4: ; 0x022393D4
 _022393E6:
 	bl NNS_GfdDoVramTransfer
 	ldr r0, [r4, #0x54]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02239400 ; =0x027E0000
 	ldr r1, _02239404 ; =0x00003FF8
 	mov r0, #1
@@ -7123,7 +7123,7 @@ _0223B3EE:
 	bl ov59_0223C374
 	bl GF_RunVramTransferTasks
 	ldr r0, [r4, #0x54]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _0223B40C ; =0x027E0000
 	ldr r1, _0223B410 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_60.s
+++ b/asm/overlay_60.s
@@ -546,7 +546,7 @@ _021E5D66:
 	bl sub_0200398C
 _021E5D74:
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	pop {r4, pc}
 	thumb_func_end ov60_021E5D44
 
@@ -4211,7 +4211,7 @@ _021E79DE:
 ov60_021E79E4: ; 0x021E79E4
 	push {r3, lr}
 	bl ov60_021E7688
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}
 	thumb_func_end ov60_021E79E4
@@ -5136,7 +5136,7 @@ _021E813A:
 ov60_021E8140: ; 0x021E8140
 	push {r3, lr}
 	bl ov60_021E7688
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}
 	thumb_func_end ov60_021E8140
@@ -6462,7 +6462,7 @@ _021E8C52:
 ov60_021E8C58: ; 0x021E8C58
 	push {r3, lr}
 	bl ov60_021E7688
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}
 	thumb_func_end ov60_021E8C58
@@ -8495,7 +8495,7 @@ _021E9D62:
 ov60_021E9D68: ; 0x021E9D68
 	push {r3, lr}
 	bl ov60_021E7688
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}
 	thumb_func_end ov60_021E9D68
@@ -10049,7 +10049,7 @@ _021EAA6E:
 ov60_021EAA74: ; 0x021EAA74
 	push {r3, lr}
 	bl ov60_021E7688
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}
 	thumb_func_end ov60_021EAA74

--- a/asm/overlay_62.s
+++ b/asm/overlay_62.s
@@ -1000,7 +1000,7 @@ ov62_021E60D4: ; 0x021E60D4
 	ldr r0, [r0]
 	cmp r0, #0
 	beq _021E60E0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 _021E60E0:
 	pop {r3, pc}
 	.balign 4, 0

--- a/asm/overlay_63.s
+++ b/asm/overlay_63.s
@@ -208,7 +208,7 @@ ov63_0221BFCC: ; 0x0221BFCC
 	str r0, [r4, #8]
 _0221BFE2:
 	ldr r0, [r4, #0x10]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	add r4, #0xa0
 	ldr r0, [r4]
 	bl sub_0200D020
@@ -5264,7 +5264,7 @@ _0221E912:
 	add r0, r4, #0
 	bl ov63_0221F1D0
 	ldr r0, [r4, #0x10]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	add r4, #0xa0
 	ldr r0, [r4]
 	bl sub_0200D020

--- a/asm/overlay_64.s
+++ b/asm/overlay_64.s
@@ -180,7 +180,7 @@ _021E5A74:
 ov64_021E5A88: ; 0x021E5A88
 	push {r3, lr}
 	ldr r0, [r0, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl sub_0200D034
 	ldr r3, _021E5AA4 ; =0x027E0000
 	ldr r1, _021E5AA8 ; =0x00003FF8

--- a/asm/overlay_65.s
+++ b/asm/overlay_65.s
@@ -1888,7 +1888,7 @@ ov65_0221CE1C: ; 0x0221CE1C
 	mov r0, #6
 	lsl r0, r0, #6
 	ldr r0, [r5, r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r0, _0221CE84 ; =0x0000211C
 	ldr r0, [r5, r0]
 	cmp r0, #0

--- a/asm/overlay_67.s
+++ b/asm/overlay_67.s
@@ -369,7 +369,7 @@ ov67_021E5BE0: ; 0x021E5BE0
 	add r4, r0, #0
 	bl ov67_021E6A00
 	ldr r0, [r4, #0x10]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E5BFC ; =0x027E0000
 	ldr r1, _021E5C00 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_68.s
+++ b/asm/overlay_68.s
@@ -290,7 +290,7 @@ ov68_021E5B6C: ; 0x021E5B6C
 	push {r4, lr}
 	add r4, r0, #0
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #0x56
 	lsl r0, r0, #2
 	ldr r0, [r4, r0]

--- a/asm/overlay_70.s
+++ b/asm/overlay_70.s
@@ -1943,7 +1943,7 @@ _022387C0:
 	blx r1
 _022387CC:
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _022387F0 ; =0x027E0000

--- a/asm/overlay_72.s
+++ b/asm/overlay_72.s
@@ -1053,7 +1053,7 @@ ov72_022380FC: ; 0x022380FC
 	add r4, r0, #0
 	bl GF_RunVramTransferTasks
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _0223811C ; =0x027E0000
 	ldr r1, _02238120 ; =0x00003FF8

--- a/asm/overlay_73.s
+++ b/asm/overlay_73.s
@@ -444,7 +444,7 @@ ov73_021E5CD8: ; 0x021E5CD8
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E5CF8 ; =0x027E0000
 	ldr r1, _021E5CFC ; =0x00003FF8
 	mov r0, #1
@@ -5076,7 +5076,7 @@ ov73_021E8100: ; 0x021E8100
 	add r4, r0, #0
 	bl GF_RunVramTransferTasks
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _021E8120 ; =0x027E0000
 	ldr r1, _021E8124 ; =0x00003FF8

--- a/asm/overlay_74_thumb.s
+++ b/asm/overlay_74_thumb.s
@@ -3151,7 +3151,7 @@ ov74_022288F8: ; 0x022288F8
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	add r0, r4, #0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02228918 ; =0x027E0000
 	ldr r1, _0222891C ; =0x00003FF8
 	mov r0, #1
@@ -24270,7 +24270,7 @@ _02233038:
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r0, [r4, #0x20]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02233058 ; =0x027E0000
 	ldr r1, _0223305C ; =0x00003FF8
 	mov r0, #1
@@ -29926,7 +29926,7 @@ _02235A8E:
 	ldr r0, [r4]
 	cmp r0, #0
 	beq _02235AA0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 _02235AA0:
 	ldr r3, _02235ABC ; =0x027E0000
 	ldr r1, _02235AC0 ; =0x00003FF8

--- a/asm/overlay_75.s
+++ b/asm/overlay_75.s
@@ -1131,7 +1131,7 @@ ov75_02247234: ; 0x02247234
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02247254 ; =0x027E0000
 	ldr r1, _02247258 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_78.s
+++ b/asm/overlay_78.s
@@ -310,7 +310,7 @@ _021E5B84:
 	bl sub_0200D034
 _021E5B8E:
 	ldr r0, [r4, #0x14]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E5BA4 ; =0x027E0000
 	ldr r1, _021E5BA8 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_80_02238648.s
+++ b/asm/overlay_80_02238648.s
@@ -458,7 +458,7 @@ ov80_02238A7C: ; 0x02238A7C
 	ldr r0, [r4, #4]
 	bl sub_0200398C
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02238AA4 ; =0x027E0000
 	ldr r1, _02238AA8 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_81.s
+++ b/asm/overlay_81.s
@@ -4439,7 +4439,7 @@ ov81_022401C8: ; 0x022401C8
 	bl sub_0200398C
 _022401EA:
 	ldr r0, [r4, #0x4c]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _02240208 ; =0x027E0000

--- a/asm/overlay_82.s
+++ b/asm/overlay_82.s
@@ -1809,7 +1809,7 @@ ov82_0223EC0C: ; 0x0223EC0C
 	bl sub_0200398C
 _0223EC24:
 	ldr r0, [r4, #0x48]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _0223EC40 ; =0x027E0000

--- a/asm/overlay_83.s
+++ b/asm/overlay_83.s
@@ -3033,7 +3033,7 @@ ov83_0223F7A0: ; 0x0223F7A0
 	bl sub_0200398C
 _0223F7B2:
 	ldr r0, [r4, #0x4c]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r0, _0223F7D8 ; =0x00000868
 	add r0, r4, r0
 	bl ov83_0224780C
@@ -12407,7 +12407,7 @@ ov83_02244488: ; 0x02244488
 	bl sub_0200398C
 _0224449A:
 	ldr r0, [r4, #0x4c]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _022444B8 ; =0x027E0000

--- a/asm/overlay_85.s
+++ b/asm/overlay_85.s
@@ -2005,7 +2005,7 @@ ov85_021E6764: ; 0x021E6764
 	bl sub_0200398C
 	ldr r0, _021E6788 ; =0x00000D84
 	ldr r0, [r4, r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	pop {r4, pc}
 	nop
 _021E6784: .word 0x00000D9C
@@ -6851,7 +6851,7 @@ ov85_021E8C14: ; 0x021E8C14
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	add r0, r4, #0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E8C34 ; =0x027E0000
 	ldr r1, _021E8C38 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_86.s
+++ b/asm/overlay_86.s
@@ -486,7 +486,7 @@ ov86_021E5CDC: ; 0x021E5CDC
 	bl sub_0200398C
 _021E5CEE:
 	ldr r0, [r4, #0xc]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl sub_0200D034
 	ldr r3, _021E5D08 ; =0x027E0000
 	ldr r1, _021E5D0C ; =0x00003FF8

--- a/asm/overlay_87.s
+++ b/asm/overlay_87.s
@@ -2365,7 +2365,7 @@ ov87_021E6C04: ; 0x021E6C04
 	bl sub_0200398C
 _021E6C1C:
 	ldr r0, [r4, #0x58]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _021E6C38 ; =0x027E0000

--- a/asm/overlay_88.s
+++ b/asm/overlay_88.s
@@ -394,7 +394,7 @@ _02258B1C: .word sub_0202457C
 ov88_02258B20: ; 0x02258B20
 	push {r3, lr}
 	ldr r0, [r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl OamManager_ApplyAndResetBuffers
 	bl GF_RunVramTransferTasks
 	pop {r3, pc}

--- a/asm/overlay_89.s
+++ b/asm/overlay_89.s
@@ -917,7 +917,7 @@ ov89_0225901C: ; 0x0225901C
 	ldr r0, [r4, #0xc]
 	bl sub_0200398C
 	ldr r0, [r4, #8]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _02259054 ; =0x027E0000
 	ldr r1, _02259058 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_90.s
+++ b/asm/overlay_90.s
@@ -1236,11 +1236,11 @@ _022590B6:
 
 	thumb_func_start ov90_022590C0
 ov90_022590C0: ; 0x022590C0
-	ldr r3, _022590C8 ; =BgConfig_HandleScheduledScrollAndTransferOps
+	ldr r3, _022590C8 ; =DoScheduledBgGpuUpdates
 	ldr r0, [r0]
 	bx r3
 	nop
-_022590C8: .word BgConfig_HandleScheduledScrollAndTransferOps
+_022590C8: .word DoScheduledBgGpuUpdates
 	thumb_func_end ov90_022590C0
 
 	thumb_func_start ov90_022590CC

--- a/asm/overlay_91.s
+++ b/asm/overlay_91.s
@@ -1778,7 +1778,7 @@ ov91_0225D2D0: ; 0x0225D2D0
 	push {r3, lr}
 	ldr r1, _0225D2E4 ; =0x00001AB4
 	ldr r0, [r0, r1]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	pop {r3, pc}

--- a/asm/overlay_92.s
+++ b/asm/overlay_92.s
@@ -2304,7 +2304,7 @@ ov92_0225D894: ; 0x0225D894
 	ldr r0, [r4, #0x5c]
 	bl sub_0200398C
 	ldr r0, [r4, #0x58]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _0225D8BC ; =0x027E0000
 	ldr r1, _0225D8C0 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_93_thumb_1.s
+++ b/asm/overlay_93_thumb_1.s
@@ -1125,7 +1125,7 @@ _0225CED8:
 	strb r1, [r4, r0]
 _0225CEEE:
 	ldr r0, [r4, #0x2c]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _0225CF0C ; =0x027E0000
 	ldr r1, _0225CF10 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_95.s
+++ b/asm/overlay_95.s
@@ -277,7 +277,7 @@ ov95_021E5B24: ; 0x021E5B24
 	ldr r0, [r4, #8]
 	bl sub_0200398C
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E5B50 ; =0x027E0000
 	ldr r1, _021E5B54 ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_96.s
+++ b/asm/overlay_96.s
@@ -3896,7 +3896,7 @@ ov96_021E75BC: ; 0x021E75BC
 	add r4, r0, #0
 	bl OamManager_ApplyAndResetBuffers
 	add r0, r4, #0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	ldr r3, _021E75DC ; =0x027E0000
 	ldr r1, _021E75E0 ; =0x00003FF8
@@ -19985,7 +19985,7 @@ _021EEEE8: .word ov96_0221B9E8
 ov96_021EEEEC: ; 0x021EEEEC
 	push {r3, lr}
 	ldr r0, [r0, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021EEF04 ; =0x027E0000
 	ldr r1, _021EEF08 ; =0x00003FF8
 	mov r0, #1
@@ -20371,7 +20371,7 @@ ov96_021EF23C: ; 0x021EF23C
 	add r4, r0, #0
 	bl sub_0200D034
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021EF258 ; =0x027E0000
 	ldr r1, _021EF25C ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_99.s
+++ b/asm/overlay_99.s
@@ -1187,7 +1187,7 @@ ov99_021E6250: ; 0x021E6250
 	add r4, r0, #0
 	bl sub_0200D034
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E626C ; =0x027E0000
 	ldr r1, _021E6270 ; =0x00003FF8
 	mov r0, #1
@@ -2030,7 +2030,7 @@ ov99_021E6938: ; 0x021E6938
 	add r4, r0, #0
 	bl sub_0200D034
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E6954 ; =0x027E0000
 	ldr r1, _021E6958 ; =0x00003FF8
 	mov r0, #1
@@ -4248,7 +4248,7 @@ ov99_021E7A54: ; 0x021E7A54
 	add r4, r0, #0
 	bl sub_0200D034
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E7A70 ; =0x027E0000
 	ldr r1, _021E7A74 ; =0x00003FF8
 	mov r0, #1
@@ -5655,7 +5655,7 @@ ov99_021E856C: ; 0x021E856C
 	add r4, r0, #0
 	bl sub_0200D034
 	ldr r0, [r4, #4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E8588 ; =0x027E0000
 	ldr r1, _021E858C ; =0x00003FF8
 	mov r0, #1

--- a/asm/overlay_trainer_card_main.s
+++ b/asm/overlay_trainer_card_main.s
@@ -2053,7 +2053,7 @@ ov51_021E6B88: ; 0x021E6B88
 	bl ov51_021E69EC
 _021E6BD2:
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r3, _021E6BF8 ; =0x027E0000

--- a/asm/overlay_trainer_card_signature.s
+++ b/asm/overlay_trainer_card_signature.s
@@ -306,7 +306,7 @@ ov52_021E837C: ; 0x021E837C
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	add r0, r4, #0
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _021E839C ; =0x027E0000
 	ldr r1, _021E83A0 ; =0x00003FF8
 	mov r0, #1

--- a/asm/unk_020755E8.s
+++ b/asm/unk_020755E8.s
@@ -3481,7 +3481,7 @@ _020772CE:
 	ldr r0, [r4, #0x14]
 	bl sub_0200398C
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _020772F0 ; =OS_IRQTable
 	ldr r1, _020772F4 ; =0x00003FF8
 	mov r0, #1

--- a/asm/unk_02078E30.s
+++ b/asm/unk_02078E30.s
@@ -1104,7 +1104,7 @@ sub_020796B8: ; 0x020796B8
 	mov r2, #3
 	bl BgSetPosTextAndCommit
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	bl GF_RunVramTransferTasks
 	bl sub_0200D034
 	ldr r3, _020796F8 ; =OS_IRQTable

--- a/asm/unk_020850F4.s
+++ b/asm/unk_020850F4.s
@@ -580,7 +580,7 @@ sub_020855CC: ; 0x020855CC
 	mov r0, #0xbe
 	lsl r0, r0, #2
 	ldr r0, [r4, r0]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _020855FC ; =OS_IRQTable
 	ldr r1, _02085600 ; =0x00003FF8
 	mov r0, #1

--- a/asm/unk_02088288.s
+++ b/asm/unk_02088288.s
@@ -396,7 +396,7 @@ sub_020885DC: ; 0x020885DC
 	push {r4, lr}
 	add r4, r0, #0
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	mov r0, #0x2a
 	lsl r0, r0, #4
 	ldr r0, [r4, r0]

--- a/asm/unk_02091CDC.s
+++ b/asm/unk_02091CDC.s
@@ -183,11 +183,11 @@ App_DeleteSave_Exit: ; 0x02091E34
 
 	thumb_func_start sub_02091E54
 sub_02091E54: ; 0x02091E54
-	ldr r3, _02091E5C ; =BgConfig_HandleScheduledScrollAndTransferOps
+	ldr r3, _02091E5C ; =DoScheduledBgGpuUpdates
 	ldr r0, [r0, #0x14]
 	bx r3
 	nop
-_02091E5C: .word BgConfig_HandleScheduledScrollAndTransferOps
+_02091E5C: .word DoScheduledBgGpuUpdates
 	thumb_func_end sub_02091E54
 
 	thumb_func_start sub_02091E60

--- a/asm/unk_020932E0.s
+++ b/asm/unk_020932E0.s
@@ -326,7 +326,7 @@ _020935B2:
 	bl GF_RunVramTransferTasks
 	bl OamManager_ApplyAndResetBuffers
 	ldr r0, [r4]
-	bl BgConfig_HandleScheduledScrollAndTransferOps
+	bl DoScheduledBgGpuUpdates
 	ldr r3, _020935D8 ; =OS_IRQTable
 	ldr r1, _020935DC ; =0x00003FF8
 	mov r0, #1

--- a/include/bg_window.h
+++ b/include/bg_window.h
@@ -257,10 +257,10 @@ u16 GetWindowBaseTile(Window *window);
 void SetWindowX(Window *window, u8 x);
 void SetWindowY(Window *window, u8 y);
 void SetWindowPaletteNum(Window *window, u8 paletteNum);
-void BgConfig_HandleScheduledScrollAndTransferOps(BgConfig *bgConfig);
-void ScheduleBgTilemapBufferTransfer(BgConfig *bgConfig, u8 layer);
-void ScheduleSetBgPosText(BgConfig *bgConfig, u8 layer, enum BgPosAdjustOp op, fx32 value);
-void ScheduleSetBgAffineScale(BgConfig *bgConfig, u8 layer, enum BgPosAdjustOp op, fx32 value);
-BOOL DoesPixelAtScreenXYMatchPtrVal(BgConfig *bgConfig, u8 layer, u8 x, u8 y, u16 *src);
+void DoScheduledBgGpuUpdates(BgConfig *bgConfig);
+void ScheduleBgTilemapBufferTransfer(BgConfig *bgConfig, u8 bgId);
+void ScheduleSetBgPosText(BgConfig *bgConfig, u8 bgId, enum BgPosAdjustOp op, fx32 value);
+void ScheduleSetBgAffineScale(BgConfig *bgConfig, u8 bgId, enum BgPosAdjustOp op, fx32 value);
+BOOL DoesPixelAtScreenXYMatchPtrVal(BgConfig *bgConfig, u8 bgId, u8 x, u8 y, u16 *src);
 
 #endif //POKEHEARTGOLD_BG_WINDOW_H

--- a/include/bg_window.h
+++ b/include/bg_window.h
@@ -21,7 +21,7 @@ typedef struct BgTemplate {
     u32 mosaic;
 } BgTemplate;
 
-typedef struct Bg {
+typedef struct Background {
     void *tilemapBuffer;
     u32 bufferSize;
     u32 baseTile;
@@ -39,20 +39,20 @@ typedef struct Bg {
     fx32 yScale;
     fx32 centerX;
     fx32 centerY;
-} Bg;
+} Background;
 
 typedef struct BgConfig {
     HeapID heapId;
     u16 scrollScheduled;
     u16 bufferTransferScheduled;
-    Bg bgs[8];
+    Background bgs[8];
 } BgConfig;
 
-typedef struct BITMAP {
+typedef struct Bitmap {
     const u8 *pixels;
     u16 width;
     u16 height;
-} BITMAP;
+} Bitmap;
 
 typedef struct WindowTemplate {
     u8 bgId;
@@ -213,19 +213,19 @@ void BG_SetMaskColor(u8 bgId, u16 value);
 void LoadRectToBgTilemapRect(BgConfig *bgConfig, u8 bgId, const void *buffer, u8 destX, u8 destY, u8 width, u8 height);
 void CopyToBgTilemapRect(BgConfig *bgConfig, u8 bgId, u8 destX, u8 destY, u8 destWidth, u8 destHeight, const void *buffer, u8 srcX, u8 srcY, u8 srcWidth, u8 srcHeight);
 void CopyRectToBgTilemapRect(BgConfig *bgConfig, u8 bgId, u8 destX, u8 destY, u8 destWidth, u8 destHeight, const void *buffer, u8 srcX, u8 srcY, u8 srcWidth, u8 srcHeight);
-void FillBgTilemapRect(BgConfig *bgConfig, u8 layer, u16 value, u8 x, u8 y, u8 width, u8 height, u8 mode);
-void BgTilemapRectChangePalette(BgConfig *bgConfig, u8 layer, u8 x, u8 y, u8 width, u8 height, u8 palette);
-void BgClearTilemapBufferAndCommit(BgConfig *bgConfig, u8 layer);
-void BgFillTilemapBufferAndCommit(BgConfig *bgConfig, u8 layer, u16 value);
-void BgFillTilemapBufferAndSchedule(BgConfig *bgConfig, u8 layer, u16 value);
-void *BgGetCharPtr(u8 layer);
-u8 *Convert4bppTo8bpp(u8 *src4Bpp, u32 size, u8 paletteNum, HeapID heap_id);
-void *GetBgTilemapBuffer(BgConfig *bgConfig, u8 layer);
-fx32 GetBgHOffset(BgConfig *bgConfig, u8 layer);
-u8 GetBgColorMode(BgConfig *bgConfig, u8 layer);
-u16 GetBgPriority(BgConfig *bgConfig, u8 layer);
-void BlitBitmapRect4Bit(const BITMAP *src, const BITMAP *dst, u16 srcX, u16 srcY, u16 dstX, u16 dstY, u16 width, u16 height, u16 colorKey);
-Window *AllocWindows(HeapID heapId, int num);
+void FillBgTilemapRect(BgConfig *bgConfig, u8 bgId, u16 fillValue, u8 x, u8 y, u8 width, u8 height, u8 mode);
+void BgTilemapRectChangePalette(BgConfig *bgConfig, u8 bgId, u8 x, u8 y, u8 width, u8 height, u8 palette);
+void BgClearTilemapBufferAndCommit(BgConfig *bgConfig, u8 bgId);
+void BgFillTilemapBufferAndCommit(BgConfig *bgConfig, u8 bgId, u16 fillValue);
+void BgFillTilemapBufferAndSchedule(BgConfig *bgConfig, u8 bgId, u16 fillValue);
+void *BgGetCharPtr(u8 bgId);
+u8 *Convert4bppTo8bpp(u8 *src4Bpp, u32 size, u8 paletteNum, HeapID heapId);
+void *GetBgTilemapBuffer(BgConfig *bgConfig, u8 bgId);
+fx32 GetBgHOffset(BgConfig *bgConfig, u8 bgId);
+u8 GetBgColorMode(BgConfig *bgConfig, u8 bgId);
+u8 GetBgPriority(BgConfig *bgConfig, u8 bgId);
+void BlitBitmapRect4Bit(const Bitmap *src, const Bitmap *dest, u16 srcX, u16 srcY, u16 destX, u16 destY, u16 width, u16 height, u16 colorKey);
+Window *AllocWindows(HeapID heapId, s32 num);
 void InitWindow(Window *window);
 BOOL WindowIsInUse(const Window *window);
 void AddWindowParameterized(BgConfig *bgConfig, Window *window, u8 layer, u8 x, u8 y, u8 width, u8 height, u8 paletteNum, u16 baseTile);

--- a/include/bg_window.h
+++ b/include/bg_window.h
@@ -61,7 +61,7 @@ typedef struct WindowTemplate {
     u8 width;
     u8 height;
     u8 palette;
-    u16 baseBlock;
+    u16 baseTile;
 } WindowTemplate;
 
 typedef struct Window {
@@ -228,11 +228,11 @@ void BlitBitmapRect4Bit(const Bitmap *src, const Bitmap *dest, u16 srcX, u16 src
 Window *AllocWindows(HeapID heapId, s32 num);
 void InitWindow(Window *window);
 BOOL WindowIsInUse(const Window *window);
-void AddWindowParameterized(BgConfig *bgConfig, Window *window, u8 layer, u8 x, u8 y, u8 width, u8 height, u8 paletteNum, u16 baseTile);
+void AddWindowParameterized(BgConfig *bgConfig, Window *window, u8 bgId, u8 x, u8 y, u8 width, u8 height, u8 paletteNum, u16 baseTile);
 void AddTextWindowTopLeftCorner(BgConfig *bgConfig, Window *window, u8 width, u8 height, u16 baseTile, u8 paletteNum);
 void AddWindow(BgConfig *bgConfig, Window *window, const WindowTemplate *template);
 void RemoveWindow(Window* window);
-void WindowArray_Delete(Window *window, int num);
+void WindowArray_Delete(Window *windows, s32 count);
 void CopyWindowToVram(Window *window);
 void ScheduleWindowCopyToVram(Window *window);
 void PutWindowTilemap(Window *window);
@@ -245,7 +245,7 @@ void FillWindowPixelBufferText_AssumeTileSize32(Window *window, u8 fillValue);
 void BlitBitmapRectToWindow(Window *window, void *src, u16 srcX, u16 srcY, u16 srcWidth, u16 srcHeight, u16 destX, u16 destY, u16 destWidth, u16 destHeight);
 void BlitBitmapRect(Window *window, void *src, u16 srcX, u16 srcY, u16 srcWidth, u16 srcHeight, u16 destX, u16 destY, u16 destWidth, u16 destHeight, u16 colorKey);
 void FillWindowPixelRect(Window *window, u8 fillValue, u16 x, u16 y, u16 width, u16 height);
-void CopyGlyphToWindow(Window *window, u8 *glyphPixels, u16 srcWidth, u16 srcHeight, u16 dstX, u16 dstY, u16 table);
+void CopyGlyphToWindow(Window *window, u8 *glyphPixels, u16 srcWidth, u16 srcHeight, u16 destX, u16 destY, u16 table);
 void ScrollWindow(Window *window, u8 direction, u8 y, u8 fillValue);
 BgConfig *GetWindowBgConfig(Window *window);
 u8 GetWindowBgId(Window *window);

--- a/include/credits/data.h
+++ b/include/credits/data.h
@@ -56,11 +56,11 @@ static const WindowTemplate ov76_021E6E98 = {
 
 static const UnkStruct_020215A0 ov76_021E6EA0 = { 0x28, 0, 0, HEAP_ID_CREDITS };
 
-static const GFBgModeSet ov76_021E6EB0 = {
+static const GraphicsModes ov76_021E6EB0 = {
     .dispMode    = GX_DISPMODE_GRAPHICS,
-    .bgModeMain  = GX_BGMODE_0,
-    .bgModeSub   = GX_BGMODE_0,
-    ._2d3dSwitch = GX_BG0_AS_2D,
+    .bgMode      = GX_BGMODE_0,
+    .subMode     = GX_BGMODE_0,
+    ._2d3dMode   = GX_BG0_AS_2D,
 };
 
 static const int sSceneTransitionTimings[5] = { 890, 1780, 2615, 3030, 4295 };
@@ -75,7 +75,7 @@ static const ScrnFileIds ov76_021E6EE8 = {
     { 0x07, 0x11, 0x09, 0x0F, 0x0D, 0x0B },
 };
 
-static const BGTEMPLATE ov76_021E6F50 = {
+static const BgTemplate ov76_021E6F50 = {
     .x          = 0,
     .y          = 0,
     .bufferSize = 0x0800,
@@ -91,7 +91,7 @@ static const BGTEMPLATE ov76_021E6F50 = {
     .mosaic     = FALSE,
 };
 
-static const BGTEMPLATE ov76_021E6F6C = {
+static const BgTemplate ov76_021E6F6C = {
     .x          = 0,
     .y          = 0,
     .bufferSize = 0x0800,
@@ -107,7 +107,7 @@ static const BGTEMPLATE ov76_021E6F6C = {
     .mosaic     = FALSE,
 };
 
-static const BGTEMPLATE ov76_021E6F88 = {
+static const BgTemplate ov76_021E6F88 = {
     .x          = 0,
     .y          = 0,
     .bufferSize = 0x0800,
@@ -123,7 +123,7 @@ static const BGTEMPLATE ov76_021E6F88 = {
     .mosaic     = FALSE,
 };
 
-static const BGTEMPLATE ov76_021E6FA4 = {
+static const BgTemplate ov76_021E6FA4 = {
     .x          = 0,
     .y          = 0,
     .bufferSize = 0x0800,
@@ -139,7 +139,7 @@ static const BGTEMPLATE ov76_021E6FA4 = {
     .mosaic     = FALSE,
 };
 
-static const BGTEMPLATE ov76_021E6F18 = {
+static const BgTemplate ov76_021E6F18 = {
     .x          = 0,
     .y          = 0,
     .bufferSize = 0x0800,
@@ -155,7 +155,7 @@ static const BGTEMPLATE ov76_021E6F18 = {
     .mosaic     = FALSE,
 };
 
-static const BGTEMPLATE ov76_021E6F34 = {
+static const BgTemplate ov76_021E6F34 = {
     .x          = 0,
     .y          = 0,
     .bufferSize = 0x0800,

--- a/include/credits/data.h
+++ b/include/credits/data.h
@@ -51,7 +51,7 @@ static const WindowTemplate ov76_021E6E98 = {
     .width     = 0x18,
     .height    = 0x18,
     .palette   = 0x0F,
-    .baseBlock = 0x0001,
+    .baseTile  = 0x0001,
 };
 
 static const UnkStruct_020215A0 ov76_021E6EA0 = { 0x28, 0, 0, HEAP_ID_CREDITS };

--- a/include/gx_layers.h
+++ b/include/gx_layers.h
@@ -4,7 +4,7 @@
 typedef enum {
     GX_LAYER_TOGGLE_OFF,
     GX_LAYER_TOGGLE_ON,
-} GX_LayerToggle;
+} GXLayerToggle;
 
 enum GFBgLayer {
     GF_BG_LYR_MAIN_0 = 0,
@@ -48,10 +48,10 @@ typedef struct GXBanksConfig {
 
 void GX_SetBanks(const GF_GXBanksConfig *banks);
 void GX_DisableEngineALayers(void);
-void GX_EngineAToggleLayers(u32 layer_mask, GX_LayerToggle enable);
+void GX_EngineAToggleLayers(u32 layer_mask, GXLayerToggle enable);
 void GX_EngineASetLayers(u32 layers);
 void GX_DisableEngineBLayers(void);
-void GX_EngineBToggleLayers(u32 layer_mask, GX_LayerToggle enable);
+void GX_EngineBToggleLayers(u32 layer_mask, GXLayerToggle enable);
 void GX_EngineBSetLayers(u32 layers);
 void GX_BothDispOn(void);
 void GX_SwapDisplay(void);

--- a/include/voltorb_flip/voltorb_flip_data.h
+++ b/include/voltorb_flip/voltorb_flip_data.h
@@ -22,7 +22,7 @@ typedef struct Ov122_021E6C2C {
 } Ov122_021E6C2C;
 
 typedef struct BgTemplates {
-    BGTEMPLATE unk0[6];
+    BgTemplate unk0[6];
 } BgTemplates;
 
 const u8 sMainMenuMsgNos[];

--- a/lib/include/nitro/mi/uncompress.h
+++ b/lib/include/nitro/mi/uncompress.h
@@ -3,7 +3,7 @@
 
 void MI_UncompressLZ8(const void *srcp, void *destp);
 
-static inline u32 MI_GetUncompressedSize(const void *srcp) {
+inline u32 MI_GetUncompressedSize(const void *srcp) {
     return (*(u32 *)srcp >> 8);
 }
 

--- a/src/battle/battle_input.c
+++ b/src/battle/battle_input.c
@@ -13,7 +13,7 @@ BattleInput *BattleInput_New() {
     return input;
 }
 
-extern BGTEMPLATE ov12_0226E5DC[4];
+extern BgTemplate ov12_0226E5DC[4];
 
 void ov12_0226604C(BgConfig *config) {
     for (int i = 0; i < NELEMS(ov12_0226E5DC); i++) {

--- a/src/battle_arcade_game_board.c
+++ b/src/battle_arcade_game_board.c
@@ -645,7 +645,7 @@ static void BattleArcade_VBlank(void *_work) {
         sub_0200398C(work->unk3D4);
     }
 
-    BgConfig_HandleScheduledScrollAndTransferOps(work->bgConfig);
+    DoScheduledBgGpuUpdates(work->bgConfig);
     GF_RunVramTransferTasks();
     OamManager_ApplyAndResetBuffers();
     OS_SetIrqCheckFlag(OS_IE_V_BLANK);

--- a/src/battle_arcade_game_board.c
+++ b/src/battle_arcade_game_board.c
@@ -658,25 +658,25 @@ static void BattleArcade_SetVramBanks() {
     GX_SetBanks(&config);
 }
 
-extern GFBgModeSet ov84_0223F924;
-extern BGTEMPLATE ov84_0223F964;
-extern BGTEMPLATE ov84_0223F980;
-extern BGTEMPLATE ov84_0223F948;
+extern GraphicsModes ov84_0223F924;
+extern BgTemplate ov84_0223F964;
+extern BgTemplate ov84_0223F980;
+extern BgTemplate ov84_0223F948;
 
 static void ov84_0223E9E4(BgConfig *config) {
-    GFBgModeSet bgModeSet = ov84_0223F924;
+    GraphicsModes bgModeSet = ov84_0223F924;
     SetBothScreensModesAndDisable(&bgModeSet);
 
-    BGTEMPLATE template = ov84_0223F964;
+    BgTemplate template = ov84_0223F964;
     InitBgFromTemplate(config, 1, &template, 0);
     BG_ClearCharDataRange(1, 32, 0, HEAP_ID_GAME_BOARD);
     BgClearTilemapBufferAndCommit(config, 1);
 
-    BGTEMPLATE template2 = ov84_0223F980;
+    BgTemplate template2 = ov84_0223F980;
     InitBgFromTemplate(config, 3, &template2, 0);
     BgClearTilemapBufferAndCommit(config, 3);
 
-    BGTEMPLATE template3 = ov84_0223F948;
+    BgTemplate template3 = ov84_0223F948;
     InitBgFromTemplate(config, 4, &template3, 0);
     BgClearTilemapBufferAndCommit(config, 4);
 

--- a/src/choose_starter_app.c
+++ b/src/choose_starter_app.c
@@ -268,12 +268,12 @@ BOOL ChooseStarterApplication_OvyInit(OVY_MANAGER *ovy, int *state_p) {
     work->bgConfig = BgConfig_Alloc(work->heapId);
 
     {
-        struct GFBgModeSet bgModeSet;
+        struct GraphicsModes bgModeSet;
 
         bgModeSet.dispMode = GX_DISPMODE_GRAPHICS;
-        bgModeSet.bgModeMain = GX_BGMODE_0;
-        bgModeSet.bgModeSub = GX_BGMODE_1;
-        bgModeSet._2d3dSwitch = GX_BG0_AS_3D;
+        bgModeSet.bgMode = GX_BGMODE_0;
+        bgModeSet.subMode = GX_BGMODE_1;
+        bgModeSet._2d3dMode = GX_BG0_AS_3D;
 
         SetBothScreensModesAndDisable(&bgModeSet);
     }
@@ -697,7 +697,7 @@ static void updateBaseAndBallsRotation(struct ChooseStarterAppWork *work) {
 static void initBgLayers(BgConfig *bgConfig, HeapID heapId) {
     G2_SetBG0Priority(2);
     {
-        const BGTEMPLATE sp70 = {
+        const BgTemplate sp70 = {
             0, 0, 0x800, 0,
             GF_BG_SCR_SIZE_256x256, GF_BG_CLR_4BPP, 0, 1, 0, 0, 0, 0,
             0
@@ -707,7 +707,7 @@ static void initBgLayers(BgConfig *bgConfig, HeapID heapId) {
         BgClearTilemapBufferAndCommit(bgConfig, 1);
     }
     {
-        const BGTEMPLATE sp54 = {
+        const BgTemplate sp54 = {
             0, 0, 0x800, 0,
             GF_BG_SCR_SIZE_256x256, GF_BG_CLR_4BPP, 1, 3, 0, 1, 0, 0,
             0
@@ -717,7 +717,7 @@ static void initBgLayers(BgConfig *bgConfig, HeapID heapId) {
         BgClearTilemapBufferAndCommit(bgConfig, 2);
     }
     {
-        const BGTEMPLATE sp38 = {
+        const BgTemplate sp38 = {
             0, 0, 0x800, 0,
             GF_BG_SCR_SIZE_256x256, GF_BG_CLR_4BPP, 2, 5, 0, 0, 0, 0,
             0
@@ -727,7 +727,7 @@ static void initBgLayers(BgConfig *bgConfig, HeapID heapId) {
         BgClearTilemapBufferAndCommit(bgConfig, 4);
     }
     {
-        const BGTEMPLATE sp1C = {
+        const BgTemplate sp1C = {
             0, 0, 0x800, 0,
             GF_BG_SCR_SIZE_256x256, GF_BG_CLR_4BPP, 0, 4, 0, 2, 0, 0,
             0
@@ -737,7 +737,7 @@ static void initBgLayers(BgConfig *bgConfig, HeapID heapId) {
         BgClearTilemapBufferAndCommit(bgConfig, 5);
     }
     {
-        const BGTEMPLATE sp00 = {
+        const BgTemplate sp00 = {
             0, 0, 0x800, 0,
             GF_BG_SCR_SIZE_256x256, GF_BG_CLR_4BPP, 1, 3, 0, 1, 0 ,0,
             0

--- a/src/choose_starter_app.c
+++ b/src/choose_starter_app.c
@@ -585,7 +585,7 @@ static void freeAllMonSprite2dResObj(struct StarterChooseMonSpriteData *a0) {
 
 static void vBlankCB(struct ChooseStarterAppWork *work) {
     OamManager_ApplyAndResetBuffers();
-    BgConfig_HandleScheduledScrollAndTransferOps(work->bgConfig);
+    DoScheduledBgGpuUpdates(work->bgConfig);
 }
 
 static void setGxBanks(void) {

--- a/src/communication_error.c
+++ b/src/communication_error.c
@@ -28,14 +28,14 @@ static const GF_GXBanksConfig sCommunicationErrorBanksConfig = {
     .texpltt = GX_VRAM_TEXPLTT_NONE,
 };
 
-static const struct GFBgModeSet sCommunicationErrorBgModeSet = {
+static const struct GraphicsModes sCommunicationErrorBgModeSet = {
     .dispMode = GX_DISPMODE_GRAPHICS,
-    .bgModeMain = GX_BGMODE_0,
-    .bgModeSub = GX_BGMODE_0,
-    ._2d3dSwitch = GX_BG0_AS_2D,
+    .bgMode = GX_BGMODE_0,
+    .subMode = GX_BGMODE_0,
+    ._2d3dMode = GX_BG0_AS_2D,
 };
 
-static const BGTEMPLATE sCommunicationErrorBgTemplate = {
+static const BgTemplate sCommunicationErrorBgTemplate = {
     .x = 0,
     .y = 0,
     .bufferSize = 0x800,

--- a/src/communication_error.c
+++ b/src/communication_error.c
@@ -58,7 +58,7 @@ static const WindowTemplate sCommunicationErrorWindowTemplate = {
     .width = 26,
     .height = 18,
     .palette = 1,
-    .baseBlock = 0x23,
+    .baseTile = 0x23,
 };
 
 static void VBlankIntr(void) {

--- a/src/credits/credits.c
+++ b/src/credits/credits.c
@@ -395,13 +395,13 @@ static void SetGXBanks(void) {
 }
 
 static void InitBgLayers(CreditsAppWork *work) {
-    GFBgModeSet modeSet;
-    BGTEMPLATE tmpl2;
-    BGTEMPLATE tmpl3;
-    BGTEMPLATE tmpl1;
-    BGTEMPLATE tmpl5;
-    BGTEMPLATE tmpl6;
-    BGTEMPLATE tmpl7;
+    GraphicsModes modeSet;
+    BgTemplate tmpl2;
+    BgTemplate tmpl3;
+    BgTemplate tmpl1;
+    BgTemplate tmpl5;
+    BgTemplate tmpl6;
+    BgTemplate tmpl7;
 
     work->bgConfig = BgConfig_Alloc(HEAP_ID_CREDITS);
     G2_BlendNone();
@@ -838,7 +838,7 @@ static void FlipScreensCB(int a0, ScreenFlipWork *a1, int a2) {
 
 static void DisplayWindow(CreditsAppWork *work) {
     AddWindow(work->bgConfig, &work->pageWork.window, &ov76_021E6E98);
-    BG_FillCharDataRange(work->bgConfig, 5, 0, 1, 0);
+    BG_FillCharDataRange(work->bgConfig, GF_BG_LYR_SUB_1, 0, 1, 0);
     LoadFontPal0(GF_BG_LYR_SUB_0, 0x1e0, HEAP_ID_CREDITS);
     GX_EngineBToggleLayers(GF_BG_LYR_MAIN_2, GX_LAYER_TOGGLE_ON);
 }

--- a/src/credits/credits.c
+++ b/src/credits/credits.c
@@ -385,7 +385,7 @@ BOOL CreditsApp_OvyExec(OVY_MANAGER *man, int *state) {
 }
 
 static void VBlankCB(CreditsAppWork *work) {
-    BgConfig_HandleScheduledScrollAndTransferOps(work->bgConfig);
+    DoScheduledBgGpuUpdates(work->bgConfig);
     OamManager_ApplyAndResetBuffers();
 }
 

--- a/src/error_message_reset.c
+++ b/src/error_message_reset.c
@@ -61,7 +61,7 @@ static const WindowTemplate sErrorMessageWindowTemplate = {
     .width = 26,
     .height = 18,
     .palette = 1,
-    .baseBlock = 0x23,
+    .baseTile = 0x23,
 };
 
 static const HEAP_PARAM sErrorMessageHeapParams = {

--- a/src/error_message_reset.c
+++ b/src/error_message_reset.c
@@ -31,14 +31,14 @@ static const GF_GXBanksConfig sErrorMessageBanksConfig = {
     .texpltt = GX_VRAM_TEXPLTT_NONE,
 };
 
-static const struct GFBgModeSet sErrorMessageBgModeSet = {
+static const struct GraphicsModes sErrorMessageBgModeSet = {
     .dispMode = GX_DISPMODE_GRAPHICS,
-    .bgModeMain = GX_BGMODE_0,
-    .bgModeSub = GX_BGMODE_0,
-    ._2d3dSwitch = GX_BG0_AS_2D,
+    .bgMode = GX_BGMODE_0,
+    .subMode = GX_BGMODE_0,
+    ._2d3dMode = GX_BG0_AS_2D,
 };
 
-static const BGTEMPLATE sErrorMessageBgTemplate = {
+static const BgTemplate sErrorMessageBgTemplate = {
     .x = 0,
     .y = 0,
     .bufferSize = 0x800,

--- a/src/field_black_out.c
+++ b/src/field_black_out.c
@@ -49,7 +49,7 @@ static void _InitDisplays(BgConfig *bgConfig) {
         GX_SetBanks(&_020FC550);
     }
     {
-        static const struct GFBgModeSet _020FC524 = {
+        static const struct GraphicsModes _020FC524 = {
             GX_DISPMODE_GRAPHICS,
             GX_BGMODE_0,
             GX_BGMODE_0,
@@ -58,7 +58,7 @@ static void _InitDisplays(BgConfig *bgConfig) {
         SetBothScreensModesAndDisable(&_020FC524);
     }
     {
-        static const BGTEMPLATE _020FC534 = {
+        static const BgTemplate _020FC534 = {
             0, 0, 0x800, 0,
             GF_BG_SCR_SIZE_256x256, GF_BG_CLR_4BPP, 31, 0, 0, 1, 0, 0, 0
         };

--- a/src/game_clear.c
+++ b/src/game_clear.c
@@ -58,14 +58,14 @@ static const GF_GXBanksConfig sGameClearSaveBanksConfig = {
     .texpltt       = GX_VRAM_TEXPLTT_01_FG,
 };
 
-static const struct GFBgModeSet sGameClearSaveBgModeSet = {
+static const struct GraphicsModes sGameClearSaveBgModeSet = {
     .dispMode    = GX_DISPMODE_GRAPHICS,
-    .bgModeMain  = GX_BGMODE_0,
-    .bgModeSub   = GX_BGMODE_0,
-    ._2d3dSwitch = GX_BG0_AS_2D,
+    .bgMode      = GX_BGMODE_0,
+    .subMode     = GX_BGMODE_0,
+    ._2d3dMode   = GX_BG0_AS_2D,
 };
 
-static const BGTEMPLATE sGameClearSaveBgTemplate = {
+static const BgTemplate sGameClearSaveBgTemplate = {
     .x          = 0,
     .y          = 0,
     .bufferSize = 0x0800,

--- a/src/gf_gfx_loader.c
+++ b/src/gf_gfx_loader.c
@@ -240,7 +240,7 @@ static u32 GfGfxLoader_LoadCharDataInternal(void *data, BgConfig *bgConfig, enum
             if (szByte == 0) {
                 szByte = pCharData->szByte;
             }
-            BG_LoadCharTilesData(bgConfig, layer, pCharData->pRawData, szByte, tileStart);
+            BG_LoadCharTilesData(bgConfig, (u8)layer, pCharData->pRawData, szByte, tileStart);
         }
         FreeToHeap(data);
     }
@@ -258,9 +258,9 @@ static void GfGfxLoader_LoadScrnDataInternal(void *data, BgConfig *bgConfig, enu
             }
             bgTilemapBuffer = GetBgTilemapBuffer(bgConfig, layer);
             if (bgTilemapBuffer != NULL) {
-                BG_LoadScreenTilemapData(bgConfig, layer, pScrnData->rawData, szByte);
+                BG_LoadScreenTilemapData(bgConfig, (u8)layer, pScrnData->rawData, szByte);
             }
-            BgCopyOrUncompressTilemapBufferRangeToVram(bgConfig, layer, pScrnData->rawData, szByte, tileStart);
+            BgCopyOrUncompressTilemapBufferRangeToVram(bgConfig, (u8)layer, pScrnData->rawData, szByte, tileStart);
         }
         FreeToHeap(data);
     }

--- a/src/gx_layers.c
+++ b/src/gx_layers.c
@@ -34,7 +34,7 @@ void GX_DisableEngineALayers(void) {
     sEngineALayers = 0;
 }
 
-void GX_EngineAToggleLayers(u32 layer_mask, GX_LayerToggle enable) {
+void GX_EngineAToggleLayers(u32 layer_mask, GXLayerToggle enable) {
     if (enable == GX_LAYER_TOGGLE_ON) {
         if (sEngineALayers & layer_mask) {
             return;
@@ -57,7 +57,7 @@ void GX_DisableEngineBLayers(void) {
     sEngineBLayers = 0;
 }
 
-void GX_EngineBToggleLayers(u32 layer_mask, GX_LayerToggle enable) {
+void GX_EngineBToggleLayers(u32 layer_mask, GXLayerToggle enable) {
     if (enable == GX_LAYER_TOGGLE_ON) {
         if (sEngineBLayers & layer_mask) {
             return;

--- a/src/save_data_read_error.c
+++ b/src/save_data_read_error.c
@@ -28,14 +28,14 @@ static const GF_GXBanksConfig sDataReadErrorBanksConfig = {
     .texpltt = GX_VRAM_TEXPLTT_NONE,
 };
 
-static const struct GFBgModeSet sDataReadErrorBgModeSet = {
+static const struct GraphicsModes sDataReadErrorBgModeSet = {
     .dispMode = GX_DISPMODE_GRAPHICS,
-    .bgModeMain = GX_BGMODE_0,
-    .bgModeSub = GX_BGMODE_0,
-    ._2d3dSwitch = GX_BG0_AS_2D,
+    .bgMode = GX_BGMODE_0,
+    .subMode = GX_BGMODE_0,
+    ._2d3dMode = GX_BG0_AS_2D,
 };
 
-static const BGTEMPLATE sDataReadErrorBgTemplate = {
+static const BgTemplate sDataReadErrorBgTemplate = {
     .x = 0,
     .y = 0,
     .bufferSize = 0x800,

--- a/src/save_data_read_error.c
+++ b/src/save_data_read_error.c
@@ -58,7 +58,7 @@ static const WindowTemplate sDataReadErrorWindowTemplate = {
     .width = 26,
     .height = 18,
     .palette = 1,
-    .baseBlock = 0x23,
+    .baseTile = 0x23,
 };
 
 void ShowSaveDataReadError(HeapID heap_id) {

--- a/src/save_data_write_error.c
+++ b/src/save_data_write_error.c
@@ -58,7 +58,7 @@ static const WindowTemplate sDataWriteErrorWindowTemplate = {
     .width = 26,
     .height = 18,
     .palette = 1,
-    .baseBlock = 0x23,
+    .baseTile = 0x23,
 };
 
 void ShowSaveDataWriteError(HeapID heap_id, int code) {

--- a/src/save_data_write_error.c
+++ b/src/save_data_write_error.c
@@ -28,14 +28,14 @@ static const GF_GXBanksConfig sDataWriteErrorBanksConfig = {
     .texpltt = GX_VRAM_TEXPLTT_NONE,
 };
 
-static const struct GFBgModeSet sDataWriteErrorBgModeSet = {
+static const struct GraphicsModes sDataWriteErrorBgModeSet = {
     .dispMode = GX_DISPMODE_GRAPHICS,
-    .bgModeMain = GX_BGMODE_0,
-    .bgModeSub = GX_BGMODE_0,
-    ._2d3dSwitch = GX_BG0_AS_2D,
+    .bgMode = GX_BGMODE_0,
+    .subMode = GX_BGMODE_0,
+    ._2d3dMode = GX_BG0_AS_2D,
 };
 
-static const BGTEMPLATE sDataWriteErrorBgTemplate = {
+static const BgTemplate sDataWriteErrorBgTemplate = {
     .x = 0,
     .y = 0,
     .bufferSize = 0x800,

--- a/src/scrcmd_c.c
+++ b/src/scrcmd_c.c
@@ -117,7 +117,7 @@ static const WindowTemplate _020FAC94 = {
     .width = 6,
     .height = 4,
     .palette = 13,
-    .baseBlock = 0x021F,
+    .baseTile = 0x021F,
 };
 
 static const u8 sConditionTable[6][3] = {

--- a/src/voltorb_flip/voltorb_flip.c
+++ b/src/voltorb_flip/voltorb_flip.c
@@ -137,7 +137,7 @@ extern const MsgNoList sMenuMsgNos[];
 extern const Ov122_021E9278 ov122_021E9278;
 extern const u16 ov122_021E92A0[8];
 extern const u8 ov122_021E92B0[4][4];
-extern const struct GFBgModeSet sVoltorbFlipBgModeSet;
+extern const struct GraphicsModes sVoltorbFlipBgModeSet;
 extern const Unk122_021E92D0 ov122_021E92D0;
 extern const Unk122_021E92E4 ov122_021E92E4;
 extern const Unk122_021E92FC ov122_021E92FC;
@@ -1695,7 +1695,7 @@ static void ov122_021E7904(Ov122_021E7888 *a0) {
 static void ov122_021E7928(VoltorbFlipAppWork *work) {
     work->bgConfig = BgConfig_Alloc(work->heapId);
 
-    const struct GFBgModeSet temp1 = sVoltorbFlipBgModeSet;
+    const struct GraphicsModes temp1 = sVoltorbFlipBgModeSet;
     SetBothScreensModesAndDisable(&temp1);
 
     BgTemplates temp2 = sVoltorbFlipBgTemplates;
@@ -1703,8 +1703,8 @@ static void ov122_021E7928(VoltorbFlipAppWork *work) {
     for (int i = 0; i < 6; i++) {
         InitBgFromTemplate(work->bgConfig, ov122_021E9270[i], &temp2.unk0[i], 0);
         BgClearTilemapBufferAndCommit(work->bgConfig, ov122_021E9270[i]);
-        BG_FillCharDataRange(work->bgConfig, ov122_021E9270[i], 0, 1, 0);
-        ToggleBgLayer(ov122_021E9270[i], 1);
+        BG_FillCharDataRange(work->bgConfig, (enum GFBgLayer)ov122_021E9270[i], 0, 1, 0);
+        ToggleBgLayer(ov122_021E9270[i], GX_LAYER_TOGGLE_ON);
     }
 }
 

--- a/src/voltorb_flip/voltorb_flip.c
+++ b/src/voltorb_flip/voltorb_flip.c
@@ -1979,7 +1979,7 @@ static void ov122_021E8004(VoltorbFlipAppWork *work) {
 
     sub_0200D020(work->unk148);
     sub_0200D034();
-    BgConfig_HandleScheduledScrollAndTransferOps(work->bgConfig);
+    DoScheduledBgGpuUpdates(work->bgConfig);
 
     REGType32v *regBase = (REGType32v *)0x027e0000;
     *(regBase + 0xffe) |= 1;

--- a/src/voltorb_flip/voltorb_flip_data2.c
+++ b/src/voltorb_flip/voltorb_flip_data2.c
@@ -7,7 +7,7 @@ const u16 ov122_021E92A0[] = {
     0x00A0, 0x00A1, 0x00C0, 0x00C1, 0x00E0, 0x00E1, 0x0100, 0x0101,
 };
 
-const struct GFBgModeSet sVoltorbFlipBgModeSet = {
+const struct GraphicsModes sVoltorbFlipBgModeSet = {
     GX_DISPMODE_GRAPHICS,
     GX_BGMODE_0,
     GX_BGMODE_0,

--- a/src/voltorb_flip/voltorb_flip_data2.c
+++ b/src/voltorb_flip/voltorb_flip_data2.c
@@ -89,7 +89,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x1B,
         .height    = 0x04,
         .palette   = 0x0C,
-        .baseBlock = 0x00A2,
+        .baseTile  = 0x00A2,
 
     },
     {
@@ -99,7 +99,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x1B,
         .height    = 0x02,
         .palette   = 0x0C,
-        .baseBlock = 0x00A2,
+        .baseTile  = 0x00A2,
 
     },
     {
@@ -109,7 +109,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x06,
         .height    = 0x06,
         .palette   = 0x0E,
-        .baseBlock = 0x010E,
+        .baseTile  = 0x010E,
 
     },
     {
@@ -119,7 +119,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x06,
         .height    = 0x02,
         .palette   = 0x0E,
-        .baseBlock = 0x0132,
+        .baseTile  = 0x0132,
 
     },
     {
@@ -129,7 +129,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x1E,
         .height    = 0x02,
         .palette   = 0x0C,
-        .baseBlock = 0x0001,
+        .baseTile  = 0x0001,
 
     },
     {
@@ -139,7 +139,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x1E,
         .height    = 0x02,
         .palette   = 0x0C,
-        .baseBlock = 0x003D,
+        .baseTile  = 0x003D,
 
     },
     {
@@ -149,7 +149,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x12,
         .height    = 0x03,
         .palette   = 0x0C,
-        .baseBlock = 0x0079,
+        .baseTile  = 0x0079,
 
     },
     {
@@ -159,7 +159,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x12,
         .height    = 0x03,
         .palette   = 0x0C,
-        .baseBlock = 0x00AF,
+        .baseTile  = 0x00AF,
 
     },
     {
@@ -169,7 +169,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x13,
         .height    = 0x04,
         .palette   = 0x0C,
-        .baseBlock = 0x00E5,
+        .baseTile  = 0x00E5,
 
     },
     {
@@ -179,7 +179,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x13,
         .height    = 0x04,
         .palette   = 0x0C,
-        .baseBlock = 0x0131,
+        .baseTile  = 0x0131,
 
     },
     {
@@ -189,7 +189,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x07,
         .height    = 0x02,
         .palette   = 0x0D,
-        .baseBlock = 0x0001,
+        .baseTile  = 0x0001,
 
     },
     {
@@ -199,7 +199,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x1E,
         .height    = 0x06,
         .palette   = 0x0C,
-        .baseBlock = 0x000F,
+        .baseTile  = 0x000F,
 
     },
     {
@@ -209,7 +209,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x15,
         .height    = 0x04,
         .palette   = 0x0C,
-        .baseBlock = 0x00C3,
+        .baseTile  = 0x00C3,
 
     },
     {
@@ -219,7 +219,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x15,
         .height    = 0x04,
         .palette   = 0x0C,
-        .baseBlock = 0x0117,
+        .baseTile  = 0x0117,
 
     },
     {
@@ -229,7 +229,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x1E,
         .height    = 0x06,
         .palette   = 0x0C,
-        .baseBlock = 0x0001,
+        .baseTile  = 0x0001,
 
     },
     {
@@ -239,7 +239,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x06,
         .height    = 0x06,
         .palette   = 0x0D,
-        .baseBlock = 0x0001,
+        .baseTile  = 0x0001,
 
     },
     {
@@ -249,7 +249,7 @@ const WindowTemplate sVoltorbFlipWindowTemplates[17] = {
         .width     = 0x1E,
         .height    = 0x08,
         .palette   = 0x0C,
-        .baseBlock = 0x0025,
+        .baseTile  = 0x0025,
 
     },
 };

--- a/src/wfc_user_info_warning.c
+++ b/src/wfc_user_info_warning.c
@@ -56,7 +56,7 @@ static const WindowTemplate sWFCWarningWindowTemplate = {
     .width = 26,
     .height = 18,
     .palette = 1,
-    .baseBlock = 0x23,
+    .baseTile = 0x23,
 };
 
 void ShowWFCUserInfoWarning(HeapID heap_id, int a1) {

--- a/src/wfc_user_info_warning.c
+++ b/src/wfc_user_info_warning.c
@@ -26,14 +26,14 @@ static const GF_GXBanksConfig sWFCWarningMsgBanksConfig = {
     .texpltt = GX_VRAM_TEXPLTT_NONE,
 };
 
-static const struct GFBgModeSet sWFCWarningMsgBgModeSet = {
+static const struct GraphicsModes sWFCWarningMsgBgModeSet = {
     .dispMode = GX_DISPMODE_GRAPHICS,
-    .bgModeMain = GX_BGMODE_0,
-    .bgModeSub = GX_BGMODE_0,
-    ._2d3dSwitch = GX_BG0_AS_2D,
+    .bgMode = GX_BGMODE_0,
+    .subMode = GX_BGMODE_0,
+    ._2d3dMode = GX_BG0_AS_2D,
 };
 
-static const BGTEMPLATE sWFCWarningBgTemplate = {
+static const BgTemplate sWFCWarningBgTemplate = {
     .x = 0,
     .y = 0,
     .bufferSize = 0x800,


### PR DESCRIPTION
I think I genuinely hate graphics programming, this is the worst part of the rom, even with all the shit I've seen and everything that doesn't make sense, this fucking file is the worst out of all of them. I genuinely hate this shit, it's actually frustrating, sometimes the bg id is a u32 and sometimes it's a u8, the enum doesn't work if it's a u8, and some parts don't match, and some parts don't match if everything is a u32, I don't get why they didn't just put it fully as one or the other, I once again question the mental capacity of the people who wrote this file in the first place, and question whether they were on drugs or having drunk some serious alcohol for this, because this shit makes barely any sense, there's shit in here which you would expect to find in gen 2, and not on a graphics system like the DS, like actually, you'd think they'd be past this by now, but of course not, since this is GF code here. This is not made any better by the fucking compiler, which only does what you'd expect half the fucking time, and the other half of the time needs a weird hack or just straight up won't work, I've had to explicitly cast to u8 a few times because that gets the compiler to work, even if the original variable is of u8, I am genuinely starting to be convinced that metrowerks, freescale, nintendo, and game freak all got together and threw a massive drug party that lasted a few months and designed and programmed the games, libraries, tools, and compilers used in it

I still have a bunch to do here, but I'm only so masochistic, and every single second I take another look at this file I am losing braincells, I need them to continue to push these roms forward, because we only have a few contributors who are working on gen 4.