### PR TITLE
Revert "field_player_avatar: Name functions related to running shoes lock"

### DIFF
--- a/asm/include/overlay_01_021E6880.inc
+++ b/asm/include/overlay_01_021E6880.inc
@@ -117,7 +117,7 @@
 .public PlayerAvatar_GetState
 .public FieldSystem_GetPlayerAvatar
 .public sub_0205CA38
-.public PlayerAvatar_CheckRunningShoesLock
+.public sub_0205CB38
 .public sub_0205CF44
 .public sub_0205CF60
 .public sub_0205CFBC

--- a/asm/include/overlay_27.inc
+++ b/asm/include/overlay_27.inc
@@ -112,8 +112,8 @@
 .public PlayerAvatar_GetState
 .public PlayerSaveData_CheckRunningShoes
 .public FieldSystem_GetPlayerAvatar
-.public PlayerAvatar_CheckRunningShoesLock
-.public PlayerAvatar_SetRunningShoesLock
+.public sub_0205CB38
+.public sub_0205CB40
 .public MapObject_GetSpriteID
 .public MapObject_GetScriptID
 .public sub_0205F330

--- a/asm/include/overlay_28.inc
+++ b/asm/include/overlay_28.inc
@@ -74,8 +74,8 @@
 .public PlayerAvatar_GetMapObject
 .public PlayerAvatar_GetState
 .public FieldSystem_GetPlayerAvatar
-.public PlayerAvatar_CheckRunningShoesLock
-.public PlayerAvatar_SetRunningShoesLock
+.public sub_0205CB38
+.public sub_0205CB40
 .public MapObject_GetSpriteID
 .public MapObject_GetScriptID
 .public sub_0205F330

--- a/asm/include/unk_02056D7C.inc
+++ b/asm/include/unk_02056D7C.inc
@@ -66,7 +66,7 @@
 .public sub_0205C6D4
 .public PlayerAvatar_GetMapObject
 .public FieldSystem_GetPlayerAvatar
-.public PlayerAvatar_CheckRunningShoesLock
+.public sub_0205CB38
 .public sub_0205DE38
 .public sub_0205DF0C
 .public sub_0205DFC8

--- a/asm/overlay_01_021E6880.s
+++ b/asm/overlay_01_021E6880.s
@@ -116,7 +116,7 @@ ov01_021E6928: ; 0x021E6928
 	bl ov01_021E6880
 	add r0, r4, #0
 	bl FieldSystem_GetPlayerAvatar
-	bl PlayerAvatar_CheckRunningShoesLock
+	bl sub_0205CB38
 	cmp r0, #0
 	beq _021E694E
 	mov r0, #2

--- a/asm/overlay_27.s
+++ b/asm/overlay_27.s
@@ -604,7 +604,7 @@ ov27_0225A48C: ; 0x0225A48C
 	ldr r0, [r5, #0x10]
 	bl FieldSystem_GetPlayerAvatar
 	add r6, r0, #0
-	bl PlayerAvatar_CheckRunningShoesLock
+	bl sub_0205CB38
 	add r4, r0, #0
 	mov r1, #1
 	eor r4, r1
@@ -613,7 +613,7 @@ ov27_0225A48C: ; 0x0225A48C
 	bl ov27_0225A468
 	add r0, r6, #0
 	add r1, r4, #0
-	bl PlayerAvatar_SetRunningShoesLock
+	bl sub_0205CB40
 _0225A4B6:
 	pop {r4, r5, r6, pc}
 	thumb_func_end ov27_0225A48C
@@ -624,7 +624,7 @@ ov27_0225A4B8: ; 0x0225A4B8
 	add r4, r0, #0
 	ldr r0, [r4, #0x10]
 	bl FieldSystem_GetPlayerAvatar
-	bl PlayerAvatar_CheckRunningShoesLock
+	bl sub_0205CB38
 	add r1, r0, #0
 	add r0, r4, #0
 	bl ov27_0225A468

--- a/asm/overlay_28.s
+++ b/asm/overlay_28.s
@@ -736,7 +736,7 @@ ov28_0225DA74: ; 0x0225DA74
 	bl ov28_0225DA1C
 	ldr r0, [r5, #0x18]
 	bl FieldSystem_GetPlayerAvatar
-	bl PlayerAvatar_CheckRunningShoesLock
+	bl sub_0205CB38
 	cmp r0, #0
 	bne _0225DB22
 	mov r0, #0x61
@@ -2642,7 +2642,7 @@ _0225E96C:
 	ldr r0, [r5, #0x18]
 	bl FieldSystem_GetPlayerAvatar
 	add r6, r0, #0
-	bl PlayerAvatar_CheckRunningShoesLock
+	bl sub_0205CB38
 	add r4, r0, #0
 	bne _0225E9B8
 	mov r0, #0x61
@@ -2671,7 +2671,7 @@ _0225E9D0:
 	mov r1, #1
 	add r0, r6, #0
 	eor r1, r4
-	bl PlayerAvatar_SetRunningShoesLock
+	bl sub_0205CB40
 _0225E9DA:
 	pop {r4, r5, r6, pc}
 	.balign 4, 0

--- a/asm/unk_02056D7C.s
+++ b/asm/unk_02056D7C.s
@@ -732,7 +732,7 @@ _020572BC:
 	cmp r0, #0
 	beq _020572CE
 	bl FieldSystem_GetPlayerAvatar
-	bl PlayerAvatar_CheckRunningShoesLock
+	bl sub_0205CB38
 	cmp r0, #0
 	beq _020572CE
 	mov r4, #1

--- a/include/field_player_avatar.h
+++ b/include/field_player_avatar.h
@@ -8,7 +8,7 @@
 
 typedef struct PlayerSaveData {
     u16 hasRunningShoes;
-    u16 runningShoesLock;
+    u16 unk2;
     u32 unk4;
 } PlayerSaveData;
 
@@ -119,7 +119,7 @@ void sub_0205CAF4(PlayerAvatar *avatar);
 BOOL sub_0205CB00(PlayerAvatar *avatar);
 void sub_0205CB14(PlayerAvatar *avatar, BOOL unkA);
 u32 sub_0205CB2C(PlayerAvatar *avatar);
-u16 PlayerAvatar_CheckRunningShoesLock(PlayerAvatar *avatar);
-void PlayerAvatar_SetRunningShoesLock(PlayerAvatar *avatar, u16 lock);
+u16 sub_0205CB38(PlayerAvatar *avatar);
+void sub_0205CB40(PlayerAvatar *avatar, u16 unkA);
 
 #endif // POKEHEARTGOLD_PlayerAvatar_H

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -443,9 +443,9 @@ void sub_0205C7B4(PlayerAvatar *avatar) {
 }
 
 void PlayerSaveData_Init(struct PlayerSaveData *playerSaveData) {
-    playerSaveData->hasRunningShoes  = 0;
-    playerSaveData->runningShoesLock = 0;
-    playerSaveData->unk4             = 0;
+    playerSaveData->hasRunningShoes = 0;
+    playerSaveData->unk2            = 0;
+    playerSaveData->unk4            = 0;
 }
 
 BOOL PlayerSaveData_CheckRunningShoes(struct PlayerSaveData *playerSaveData) {
@@ -724,10 +724,10 @@ u32 sub_0205CB2C(PlayerAvatar *avatar) {
     return sub_0205C73C(avatar, 128);
 }
 
-u16 PlayerAvatar_CheckRunningShoesLock(PlayerAvatar *avatar) {
-    return avatar->playerSaveData->runningShoesLock;
+u16 sub_0205CB38(PlayerAvatar *avatar) {
+    return avatar->playerSaveData->unk2;
 }
 
-void PlayerAvatar_SetRunningShoesLock(PlayerAvatar *avatar, u16 lock) {
-    avatar->playerSaveData->runningShoesLock = lock;
+void sub_0205CB40(PlayerAvatar *avatar, u16 unkA) {
+    avatar->playerSaveData->unk2 = unkA;
 }


### PR DESCRIPTION
Reverts pret/pokeheartgold#346

Are we even sure that's what the purpose of this field is? Its usage seems dubious.