### PR TITLE
Update evo.json

### DIFF
--- a/files/poketool/personal/evo.json
+++ b/files/poketool/personal/evo.json
@@ -3,7 +3,6 @@
     [
         { "baseSpecies": "SPECIES_BULBASAUR", "evos": [ { "method": "EVO_LEVEL", "param": 16, "target": "SPECIES_IVYSAUR" } ] },
         { "baseSpecies": "SPECIES_IVYSAUR", "evos": [ { "method": "EVO_LEVEL", "param": 32, "target": "SPECIES_VENUSAUR" } ] },
-        { "baseSpecies": "SPECIES_CHARMANDER", "evos": [ { "method": "EVO_LEVEL", "param": 36, "target": "SPECIES_VENUSAUR" } ] },
         { "baseSpecies": "SPECIES_CHARMANDER", "evos": [ { "method": "EVO_LEVEL", "param": 16, "target": "SPECIES_CHARMELEON" } ] },
         { "baseSpecies": "SPECIES_CHARMELEON", "evos": [ { "method": "EVO_LEVEL", "param": 36, "target": "SPECIES_CHARIZARD" } ] },
         { "baseSpecies": "SPECIES_SQUIRTLE", "evos": [ { "method": "EVO_LEVEL", "param": 16, "target": "SPECIES_WARTORTLE" } ] },
@@ -155,9 +154,9 @@
         { "baseSpecies": "SPECIES_PORYGON2", "evos": [ { "method": "EVO_TRADE_ITEM", "param": "ITEM_DUBIOUS_DISC", "target": "SPECIES_PORYGON_Z" } ] },
         { "baseSpecies": "SPECIES_TYROGUE", "evos":
             [
-                { "method": "EVO_LEVEL_ATK_LT_DEF", "param": "20", "target": "SPECIES_HITMONCHAN" },
-                { "method": "EVO_LEVEL_ATK_GT_DEF", "param": "20", "target": "SPECIES_HITMONLEE" },
-                { "method": "EVO_LEVEL_ATK_EQ_DEF", "param": "20", "target": "SPECIES_HITMONTOP" }
+                { "method": "EVO_LEVEL_ATK_LT_DEF", "param": 20, "target": "SPECIES_HITMONCHAN" },
+                { "method": "EVO_LEVEL_ATK_GT_DEF", "param": 20, "target": "SPECIES_HITMONLEE" },
+                { "method": "EVO_LEVEL_ATK_EQ_DEF", "param": 20, "target": "SPECIES_HITMONTOP" }
             ]
         },
         { "baseSpecies": "SPECIES_SMOOCHUM", "evos": [ { "method": "EVO_LEVEL", "param": 30, "target": "SPECIES_JYNX" } ] },


### PR DESCRIPTION
There's an extra entry for Charmander Evolving into Venusaur for some reason. The parameters for comparing Tyrogue's stats when evolving are set as "param": "30", isn't it supposed to be "param": 30 instead?