### PR TITLE
Fix one init script and bare noops

### DIFF
--- a/asm/macros/script.inc
+++ b/asm/macros/script.inc
@@ -15,7 +15,7 @@
 	.endm
 
 	; Dummy command
-	.macro Nop
+	.macro Noop
 	.short 0
 	.endm
 

--- a/files/fielddata/script/scr_seq/scr_seq_0286_D22R0101_hdr.s
+++ b/files/fielddata/script/scr_seq/scr_seq_0286_D22R0101_hdr.s
@@ -1,18 +1,18 @@
 #include "constants/scrcmd.h"
 #include "fielddata/script/scr_seq/event_D22R0101.h"
+#include "constants/init_script_types.h"
+	.include "asm/macros/script.inc"
+
 	.rodata
 	.option alignment off
 
-	.byte 1
-	.word scr_seq_D22R0101_map_scripts_2-.-4 // var check (on frame table)
-	.byte 3
-	.short _EV_scr_seq_D22R0101_011 + 1, 0 // when a fadescreen happens (called on_load)
-	.byte 2
-	.short _EV_scr_seq_D22R0101_025 + 1, 0 // on enter (on map load, actually on_transition here)
-	.byte 0
+	InitScriptEntry_OnFrameTable scr_seq_D22R0101_map_scripts_2
+	InitScriptEntry_OnResume _EV_scr_seq_D22R0101_011 + 1, 0
+	InitScriptEntry_OnTransition _EV_scr_seq_D22R0101_025 + 1, 0
+	InitScriptEntryEnd
 
 scr_seq_D22R0101_map_scripts_2:
-	.short VAR_UNK_40F7, 1, std_bug_contest_judging
-	.short 0
+	InitScriptGoToIfEqual VAR_UNK_40F7, 1, std_bug_contest_judging
+	InitScriptFrameTableEnd
 
-	.balign 4, 0
+	InitScriptEnd

--- a/files/fielddata/script/scr_seq/scr_seq_0803_T07R0401.s
+++ b/files/fielddata/script/scr_seq/scr_seq_0803_T07R0401.s
@@ -322,7 +322,7 @@ _048B:
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _052E
 	CheckGiveCoins VAR_SPECIAL_RESULT, 50
-	.short 0 ; Nop
+	Noop
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _0523
 	SubMoneyImmediate 1000
@@ -340,7 +340,7 @@ _04D7:
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _052E
 	CheckGiveCoins VAR_SPECIAL_RESULT, 500
-	.short 0 ; Nop
+	Noop
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _0523
 	SubMoneyImmediate 10000
@@ -381,7 +381,7 @@ scr_seq_T07R0401_005:
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _05AA
 	CheckGiveCoins VAR_SPECIAL_RESULT, 18
-	.short 0 ; Nop
+	Noop
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _05B9
 	GiveCoins 18

--- a/files/fielddata/script/scr_seq/scr_seq_0906_T25R1101.s
+++ b/files/fielddata/script/scr_seq/scr_seq_0906_T25R1101.s
@@ -501,7 +501,7 @@ _06FE:
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _07A1
 	CheckGiveCoins VAR_SPECIAL_RESULT, 50
-	.short 0 ; Nop
+	Noop
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _0796
 	SubMoneyImmediate 1000
@@ -519,7 +519,7 @@ _074A:
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _07A1
 	CheckGiveCoins VAR_SPECIAL_RESULT, 500
-	.short 0 ; Nop
+	Noop
 	Compare VAR_SPECIAL_RESULT, 0
 	GoToIfEq _0796
 	SubMoneyImmediate 10000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
some oversights i found while testing rotom, these were from when i was converting scripts to PascalCase and levelscripts to proper macros.
- one levelscript was still using raw assembly
- Nop was still `.short 0` in scripts. ive also renamed it to `Noop` because mwasmarm was treating it as an assembler instruction

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] The ROM compiles to matching locally (`make compare_heartgold && make compare_soulsilver`).
- [x] All C code is correctly formatted (`git clang-format`).
- [x] This pull request is labeled according to the kind of work it represents.
- [x] New or updated code labels follow the [style guide]()
- [x] This work adheres to the [AI policy](CONTRIBUTING.md#ai-policy).
- [x] The author has joined the [pret discord server](https://discord.gg/d5dubZ3) and sent a message in #pokeheartgold to verify that they are human
