### PR TITLE
Yoink pr-lint.yml from plat (for real this time)

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,33 @@
+name: pr-lint
+on:
+  pull_request:
+    branches: [main]
+    paths: ['**.c', '**.h']
+  workflow_dispatch: {}
+
+jobs:
+  pr-lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cpp-linter/cpp-linter-action@v2.18.0
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: 'file' # Use repository .clang-format file
+          tidy-checks: '-*' # Disable clang-tidy checks
+          version: '19'
+          files-changed-only: false # Github returns error code 406 if more than 300 files are changed in a PR
+          ignore: '.github|lib|subprojects|tools'
+          file-annotations: false
+
+      - name: fail fast
+        if: steps.linter.outputs.clang-format-checks-failed > 0
+        run: exit 1


### PR DESCRIPTION
Direct copy and paste, standardizes clang-format at version 19 but that's easy to change if we decide differently.

The linter is meant to fail whenever it's clear the user didn't run ``format.sh`` before opening the PR.

<!--- Provide a general summary of your changes in the Title above -->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] The ROM compiles to matching locally (`make compare_heartgold && make compare_soulsilver`).
- [X] All C code is correctly formatted (`git clang-format`).
- [X] This pull request is labeled according to the kind of work it represents.
- [X] New or updated code labels follow the [style guide](https://docs.google.com/document/d/17D62q1v4dcBmet8T8uYoTAP_0IdGTci0-3p0fPcf-a8/edit)
- [X] This work adheres to the [AI policy](CONTRIBUTING.md#ai-policy).
- [X] The author has joined the [pret discord server](https://discord.gg/d5dubZ3) and sent a message in #pokeheartgold to verify that they are human
