### PR TITLE
Fix branch name discrepency in pr-lint.yml

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: pr-lint
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
     paths: ['**.c', '**.h']
   workflow_dispatch: {}
 


### PR DESCRIPTION
I forgot that the main branch is named differently in pokeheartgold, so the linter wasn't triggering before

<!--- Provide a general summary of your changes in the Title above -->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] The ROM compiles to matching locally (`make compare_heartgold && make compare_soulsilver`).
- [X] All C code is correctly formatted (`git clang-format`).
- [X] This pull request is labeled according to the kind of work it represents.
- [X] New or updated code labels follow the [style guide](https://docs.google.com/document/d/17D62q1v4dcBmet8T8uYoTAP_0IdGTci0-3p0fPcf-a8/edit)
- [X] This work adheres to the [AI policy](CONTRIBUTING.md#ai-policy).
- [X] The author has joined the [pret discord server](https://discord.gg/d5dubZ3) and sent a message in #pokeheartgold to verify that they are human
