### PR TITLE
Add Exception to files/.gitignore for item icon NCLRs

### DIFF
--- a/files/.gitignore
+++ b/files/.gitignore
@@ -97,3 +97,4 @@ demo/intro/intro.narc
 data/namein.narc
 data/sbox_gra.narc
 *.NCLR
+!itemtool/itemdata/item_icon/*.NCLR


### PR DESCRIPTION
Added item icon palettes are ignored by the blanket `*.NCLR` glob in `files/.gitignore`. Add an exception for these.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] The ROM compiles to matching locally (`make compare_heartgold && make compare_soulsilver`).
- [X] All C code is correctly formatted (`git clang-format`).
- [X] This pull request is labeled according to the kind of work it represents.
- [X] New or updated code labels follow the [style guide](https://docs.google.com/document/d/17D62q1v4dcBmet8T8uYoTAP_0IdGTci0-3p0fPcf-a8/edit)
- [X] This work adheres to the [AI policy](CONTRIBUTING.md#ai-policy).
- [X] The author has joined the [pret discord server](https://discord.gg/d5dubZ3) and sent a message in #pokeheartgold to verify that they are human
